### PR TITLE
Add the missing page: scheduling

### DIFF
--- a/kr/documentation.md
+++ b/kr/documentation.md
@@ -104,6 +104,8 @@
     - [패키지 개발](/docs/{{version}}/packages)
     - [Queues](/docs/{{version}}/queues)
     - [Queues-큐](/docs/{{version}}/queues)
+    - [Scheduled Tasks](/docs/{{version}}/scheduling)
+    - [작업 스케쥴링](/docs/{{version}}/scheduling)
 - Database
 - 데이터베이스
     - [Getting Started](/docs/{{version}}/database)

--- a/kr/documentation.md
+++ b/kr/documentation.md
@@ -105,7 +105,7 @@
     - [Queues](/docs/{{version}}/queues)
     - [Queues-큐](/docs/{{version}}/queues)
     - [Scheduled Tasks](/docs/{{version}}/scheduling)
-    - [작업 스케쥴링](/docs/{{version}}/scheduling)
+    - [작업 스케줄링](/docs/{{version}}/scheduling)
 - Database
 - 데이터베이스
     - [Getting Started](/docs/{{version}}/database)


### PR DESCRIPTION
5.4 매뉴얼에 “작업 스케줄링” 메뉴가 없어요…
메뉴 제목이 “Scheduled Task”로 변경되었지만 도큐먼트 안의 제목은 “Task Scheduling” 기존 그대로라서 그냥 예전에 쓰던 한글 제목 그대로 넣습니다.