### PR TITLE
Add the missing page: scheduling

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -51,7 +51,7 @@
     - [Notifications-알림](/docs/{{version}}/notifications)
     - [패키지 개발](/docs/{{version}}/packages)
     - [Queues-큐](/docs/{{version}}/queues)
-    - [작업 스케쥴링](/docs/{{version}}/scheduling)
+    - [작업 스케줄링](/docs/{{version}}/scheduling)
 - 데이터베이스
     - [시작하기](/docs/{{version}}/database)
     - [쿼리 빌더](/docs/{{version}}/queries)

--- a/documentation.md
+++ b/documentation.md
@@ -51,6 +51,7 @@
     - [Notifications-알림](/docs/{{version}}/notifications)
     - [패키지 개발](/docs/{{version}}/packages)
     - [Queues-큐](/docs/{{version}}/queues)
+    - [작업 스케쥴링](/docs/{{version}}/scheduling)
 - 데이터베이스
     - [시작하기](/docs/{{version}}/database)
     - [쿼리 빌더](/docs/{{version}}/queries)


### PR DESCRIPTION
* pre-kr-5.4 내용과 동일합니다 :)
5.4 매뉴얼에 “작업 스케줄링” 메뉴가 없어요…
메뉴 제목이 “Scheduled Task”로 변경되었지만 도큐먼트 안의 제목은 “Task Scheduling” 기존 그대로라서 그냥 예전에 쓰던 한글 제목 그대로 넣습니다.