### PR TITLE
passport, socialite 변경사항 없음

### DIFF
--- a/kr/passport.md
+++ b/kr/passport.md
@@ -1,60 +1,106 @@
 # API Authentication (Passport)
+# API 인증(Passport)
 
 - [Introduction](#introduction)
+- [소개하기](#introduction)
 - [Installation](#installation)
+- [설치하기](#installation)
     - [Frontend Quickstart](#frontend-quickstart)
+    - [프론트 엔드 빠른시작](#frontend-quickstart)
     - [Deploying Passport](#deploying-passport)
+    - [Passport 배포하기](#deploying-passport)
 - [Configuration](#configuration)
+- [설정하기](#configuration)
+    - [Token Lifetimes](#token-lifetimes)
     - [Token Lifetimes](#token-lifetimes)
 - [Issuing Access Tokens](#issuing-access-tokens)
+- [Issuing Access Tokens](#issuing-access-tokens)
+    - [Managing Clients](#managing-clients)
     - [Managing Clients](#managing-clients)
     - [Requesting Tokens](#requesting-tokens)
+    - [Requesting Tokens](#requesting-tokens)
+    - [Refreshing Tokens](#refreshing-tokens)
     - [Refreshing Tokens](#refreshing-tokens)
 - [Password Grant Tokens](#password-grant-tokens)
+- [Password Grant Tokens](#password-grant-tokens)
+    - [Creating A Password Grant Client](#creating-a-password-grant-client)
     - [Creating A Password Grant Client](#creating-a-password-grant-client)
     - [Requesting Tokens](#requesting-password-grant-tokens)
+    - [Requesting Tokens](#requesting-password-grant-tokens)
+    - [Requesting All Scopes](#requesting-all-scopes)
     - [Requesting All Scopes](#requesting-all-scopes)
 - [Implicit Grant Tokens](#implicit-grant-tokens)
+- [Implicit Grant Tokens](#implicit-grant-tokens)
+- [Client Credentials Grant Tokens](#client-credentials-grant-tokens)
 - [Client Credentials Grant Tokens](#client-credentials-grant-tokens)
 - [Personal Access Tokens](#personal-access-tokens)
+- [Personal Access Tokens](#personal-access-tokens)
+    - [Creating A Personal Access Client](#creating-a-personal-access-client)
     - [Creating A Personal Access Client](#creating-a-personal-access-client)
     - [Managing Personal Access Tokens](#managing-personal-access-tokens)
+    - [Managing Personal Access Tokens](#managing-personal-access-tokens)
+- [Protecting Routes](#protecting-routes)
 - [Protecting Routes](#protecting-routes)
     - [Via Middleware](#via-middleware)
+    - [Via Middleware](#via-middleware)
+    - [Passing The Access Token](#passing-the-access-token)
     - [Passing The Access Token](#passing-the-access-token)
 - [Token Scopes](#token-scopes)
+- [Token Scopes](#token-scopes)
+    - [Defining Scopes](#defining-scopes)
     - [Defining Scopes](#defining-scopes)
     - [Assigning Scopes To Tokens](#assigning-scopes-to-tokens)
+    - [Assigning Scopes To Tokens](#assigning-scopes-to-tokens)
+    - [Checking Scopes](#checking-scopes)
     - [Checking Scopes](#checking-scopes)
 - [Consuming Your API With JavaScript](#consuming-your-api-with-javascript)
+- [Consuming Your API With JavaScript](#consuming-your-api-with-javascript)
 - [Events](#events)
+- [이벤트](#events)
 - [Testing](#testing)
+- [테스팅](#testing)
 
 <a name="introduction"></a>
 ## Introduction
+## 소개하기
 
 Laravel already makes it easy to perform authentication via traditional login forms, but what about APIs? APIs typically use tokens to authenticate users and do not maintain session state between requests. Laravel makes API authentication a breeze using Laravel Passport, which provides a full OAuth2 server implementation for your Laravel application in a matter of minutes. Passport is built on top of the [League OAuth2 server](https://github.com/thephpleague/oauth2-server) that is maintained by Alex Bilbie.
 
+라라벨은 이미 전통적인 로그인 폼을 통한 사용자 인증을 손쉽게 사용할 수 있는 방법을 가지고 있습니다. 하지만 API의 경우에는 어떨까요? API는 일반적으로 사용자 인증을 위해서 토큰을 사용하고 request-요청에서는 세션을 사용하지 않습니다. 라라벨은 어플리케이션에 Full OAuth2 서버 구현을 제공하는 Passport를 사용하여 API 인증을 용이하게 합니다. Passport 는 Alex Bilbie에 의해서 관리되고 있는 [League OAuth2 server](https://github.com/thephpleague/oauth2-server) 위에 구성되어 있습니다.
+
 > {note} This documentation assumes you are already familiar with OAuth2. If you do not know anything about OAuth2, consider familiarizing yourself with the general terminology and features of OAuth2 before continuing.
+
+> {note} 이 문서는 여러분이 OAuth2에 익숙하다고 전제하고 있습니다. OAuth2 대해 잘 모르겠다면, 문서를 읽기 전에 OAuth2에서 사용되는 일반적인 용어와 기능들을 숙지해 주십시오.
 
 <a name="installation"></a>
 ## Installation
+## 설치하기
 
 To get started, install Passport via the Composer package manager:
+
+컴포저를 통해서 Passport를 설치하는 것부터 시작해보겠습니다:
 
     composer require laravel/passport
 
 The Passport service provider registers its own database migration directory with the framework, so you should migrate your database after registering the provider. The Passport migrations will create the tables your application needs to store clients and access tokens:
 
+Passport 서비스 프로바이더는 고유한 데이터베이스 마이그레이션 디렉토리를 등록하기 때문에, 서비스 프로바이더를 등록한 뒤에 데이터베이스 마이그레이션을 실행해야 합니다. Passport 마이그레이션을 실행하면 어플리케이션에서 필요한 클라이언트와 엑세스 토큰을 저장하는 테이블이 생성됩니다:
+
     php artisan migrate
 
 > {note} If you are not going to use Passport's default migrations, you should call the `Passport::ignoreMigrations` method in the `register` method of your `AppServiceProvider`. You may export the default migrations using `php artisan vendor:publish --tag=passport-migrations`.
 
+> {note} passport 기본 마이그레이션을 사용하지 않는다면, `AppServiceProvider`파일의 `register` 메소드 안에서 `Passport::ignoreMigrations` 를 호출해야합니다. `php artisan vendor:publish --tag=passport-migrations` 명령어를 사용하여 기본 마에그레이션 파일을 확인할 수 있습니다.
+
 Next, you should run the `passport:install` command. This command will create the encryption keys needed to generate secure access tokens. In addition, the command will create "personal access" and "password grant" clients which will be used to generate access tokens:
+
+다음으로, `passport:install` 명령어를 실행해야합니다. 이 명령어는 안전한 엑세스 토큰을 생성하는데 필요한 암호화 키를 생성합니다. 추가적으로, 명령어는 엑세스 토큰을 생성하는데 사용되는 "personal access" 그리고 "password grant" 클라이언트를 생성합니다:
 
     php artisan passport:install
 
 After running this command, add the `Laravel\Passport\HasApiTokens` trait to your `App\User` model. This trait will provide a few helper methods to your model which allow you to inspect the authenticated user's token and scopes:
+
+이 명령어를 실행한 후에, `App\User` 모델에 `Laravel\Passport\HasApiTokens` 트레이트-trait 를 추가하십시오. 이 트레이트-trait는 모델에 인증된 사용자의 토큰과 범위를 확인하기 위한 몇가지 헬퍼 메소드를 제공합니다:
 
     <?php
 
@@ -70,6 +116,8 @@ After running this command, add the `Laravel\Passport\HasApiTokens` trait to you
     }
 
 Next, you should call the `Passport::routes` method within the `boot` method of your `AuthServiceProvider`. This method will register the routes necessary to issue access tokens and revoke access tokens, clients, and personal access tokens:
+
+다음으로, `AuthServiceProvider` 의 `boot` 메소드에서 `Passport::routes` 메소드를 호출해야 합니다. 이 메소드는 엑세스 토큰을 발급하는 라우트와 엑세스 토큰, 클라이언트 그리고 개인용 엑세스 토큰을 해제하는 라우트를 등록합니다:
 
     <?php
 
@@ -105,6 +153,8 @@ Next, you should call the `Passport::routes` method within the `boot` method of 
 
 Finally, in your `config/auth.php` configuration file, you should set the `driver` option of the `api` authentication guard to `passport`. This will instruct your application to use Passport's `TokenGuard` when authenticating incoming API requests:
 
+마지막으로, `config/auth.php` 설정 파일에서 guard `api` 인증 `driver` 옵션을 `passport` 로 변경해야 합니다. 이렇게 하면, 인증 API request이 유입될 때 어플리케이션이 Passport의 `TokenGuard` 를 사용합니다:
+
     'guards' => [
         'web' => [
             'driver' => 'session',
@@ -119,16 +169,25 @@ Finally, in your `config/auth.php` configuration file, you should set the `drive
 
 <a name="frontend-quickstart"></a>
 ### Frontend Quickstart
+### 빠른 프론트엔드 시작하기
 
 > {note} In order to use the Passport Vue components, you must be using the [Vue](https://vuejs.org) JavaScript framework. These components also use the Bootstrap CSS framework. However, even if you are not using these tools, the components serve as a valuable reference for your own frontend implementation.
 
+> {note} Passport 의 Vue 컴포넌트를 사용하려면, 여러분은 [Vue](https://vuejs.org) 자바스크립트 프레임워크를 사용해야만 합니다. 또한 이 컴포넌트는 부트스트랩 CSS 프레임워크도 사용합니다. 이러한 툴들을 사용하지 않더라도, 여러분의 고유한 프론트엔드 구현을 위한 주요한 참고 자료로 사용될 수 있습니다.
+
 Passport ships with a JSON API that you may use to allow your users to create clients and personal access tokens. However, it can be time consuming to code a frontend to interact with these APIs. So, Passport also includes pre-built [Vue](https://vuejs.org) components you may use as an example implementation or starting point for your own implementation.
 
+Passport 는 여러분의 사용자가 클라이언트와 개인용 엑세스 토큰을 생성하는 것을 가능하게 하는 JSON API를 제공합니다. 하지만 이런 API에 대한 프론트엔드를 구성하는데는 시간이 필요합니다. 그래서 Pssport는 여러분이 사용할 수 있는 구현 예제 또는 고유한 구현을 위한 참고가 될 수 있도록 사전에 작성해놓은 [Vue](https://vuejs.org) 컴포넌트를 포함하고 있습니다. 
+
 To publish the Passport Vue components, use the `vendor:publish` Artisan command:
+
+Passport Vue 컴포넌트를 퍼블리싱 하려면, `vendor:publish` 아티즌 명령어를 사용하면 됩니다:
 
     php artisan vendor:publish --tag=passport-components
 
 The published components will be placed in your `resources/assets/js/components` directory. Once the components have been published, you should register them in your `resources/assets/js/app.js` file:
+
+퍼블리싱이 끝난 컴포넌트는 `resources/assets/js/components` 디렉토리에 설치됩니다. 컴포넌트가 퍼블리싱되고 나면, `resources/assets/js/app.js` 파일에 등록해야합니다:
 
     Vue.component(
         'passport-clients',
@@ -147,24 +206,33 @@ The published components will be placed in your `resources/assets/js/components`
 
 After registering the components, make sure to run `npm run dev` to recompile your assets. Once you have recompiled your assets, you may drop the components into one of your application's templates to get started creating clients and personal access tokens:
 
+컴포넌트를 등록하고 나서 asset을 컴파일 하기 위해서 `npm run dev`를 실행하십시오. asset을 컴파일 하고나면, 클라이언트와 개인용 엑세스 토큰을 생성하기 위해서 어플리케이션의 템플릿에 다음 코드를 복사하십시오:  
+
     <passport-clients></passport-clients>
     <passport-authorized-clients></passport-authorized-clients>
     <passport-personal-access-tokens></passport-personal-access-tokens>
 
 <a name="deploying-passport"></a>
 ### Deploying Passport
+### Passport 배포하기
 
 When deploying Passport to your production servers for the first time, you will likely need to run the `passport:keys` command. This command generates the encryption keys Passport needs in order to generate access token. The generated keys are not typically kept in source control:
+
+Passport 를 실서버에 맨 처음 배포할 때, `passport:keys` 명령어가 필요할 수 있습니다. 이 명령어는 액세스 토큰을 생성하기 위해 Passport에서 필요한 암호화된 키를 생성합니다. 생성 된 키는 일반적으로 소스 컨트롤에 유지되지 않습니다:
 
     php artisan passport:keys
 
 <a name="configuration"></a>
 ## Configuration
+## 설정하기
 
 <a name="token-lifetimes"></a>
 ### Token Lifetimes
+### 토큰 지속시간
 
 By default, Passport issues long-lived access tokens that never need to be refreshed. If you would like to configure a shorter token lifetime, you may use the `tokensExpireIn` and `refreshTokensExpireIn` methods. These methods should be called from the `boot` method of your `AuthServiceProvider`:
+
+기본적으로 Passport 는 다시 생성할 필요없도록 오래동안 지속되는 엑세스 토큰을 발급합니다. 토큰의 지속시간을 더 짧게 줄이려면, `tokensExpireIn` 그리고 `refreshTokensExpireIn` 메소드를 사용하면 됩니다. 이 메소드는 `AuthServiceProvider` 의 `boot` 메소드에서 호출되어야 합니다:
 
     /**
      * Register any authentication / authorization services.
@@ -184,31 +252,50 @@ By default, Passport issues long-lived access tokens that never need to be refre
 
 <a name="issuing-access-tokens"></a>
 ## Issuing Access Tokens
+## 엑세스 토큰 발급하기
 
 Using OAuth2 with authorization codes is how most developers are familiar with OAuth2. When using authorization codes, a client application will redirect a user to your server where they will either approve or deny the request to issue an access token to the client.
 
+승인 코드와 함께 OAuth2를 사용하는 것은 대부분의 개발자가 OAuth2를 사용하는 가장 익숙한 방법입니다. 승인 코드를 사용할 때, 클라이언트 어플리케이션은 사용자를 서버로 리다이렉션 시켜서, 클라이언트에 대한 엑세스 토큰을 발급하는 요청-request를 승인하거나, 거부하게 됩니다.
+
 <a name="managing-clients"></a>
 ### Managing Clients
+### 클라이언트 관리
 
 First, developers building applications that need to interact with your application's API will need to register their application with yours by creating a "client". Typically, this consists of providing the name of their application and a URL that your application can redirect to after users approve their request for authorization.
 
+먼저, 어플리케이션의 API와 인터렉션을 해야하는 어플리케이션을 작성하는 개발자는 하나의 "클라이언트"를 만들어 어플리케이션에 등록해야 합니다. 일반적으로 이것은 어플리케이션의 이름과 사용자가 reqeust을 승인한 뒤에 어플리케이션이 리다렉션 할 수 있는 URL을 제공하여 구성합니다.
+
 #### The `passport:client` Command
+#### `passport:client` 명령어
 
 The simplest way to create a client is using the `passport:client` Artisan command. This command may be used to create your own clients for testing your OAuth2 functionality. When you run the `client` command, Passport will prompt you for more information about your client and will provide you with a client ID and secret:
+
+클라이언트를 만드는 가장 간단한 방법은 `passport:client` 아티즌 명령어를 사용하는 것입니다. 이 명령어는 OAuth2 기능을 테스트하는 여러분의 고유한 클라이언트를 생성하는데 사용될 수 있습니다. 여러분이 `client` 명령어를 실행하면, Passport는 클리이언트에 대한 보다 자세한 정보를 물어보는 메세지를 표시하고 클라이언트의 ID 와 암호를 제공합니다:
 
     php artisan passport:client
 
 #### JSON API
+#### JSON API
 
 Since your users will not be able to utilize the `client` command, Passport provides a JSON API that you may use to create clients. This saves you the trouble of having to manually code controllers for creating, updating, and deleting clients.
 
+여러분의 사용자는 `client` 명령어를 사용할 수 없기 때문에, Passport 는 클라이언트를 생성하는데 사용할 수 있는 JSON API를 제공합니다. 이렇게 하면, 일일이 클라이언트를 생성하고, 수정하고, 삭제하는 컨트롤러 코드를 구성해야 하는 문제에서 벗어날 수 있습니다. 
+
 However, you will need to pair Passport's JSON API with your own frontend to provide a dashboard for your users to manage their clients. Below, we'll review all of the API endpoints for managing clients. For convenience, we'll use [Axios](https://github.com/mzabriskie/axios) to demonstrate making HTTP requests to the endpoints.
+
+그렇지만, Passport JSON API에 대응하는 대시보드를 통해서 사용자가 클라이언트를 관리할 수 있도록 프론트 엔드를 구성해야 합니다. 아래에서, 클라이언트를 관리하는 모든 API 엔드포인트를 확인해보겠습니다. 편의를 위해서, 엔드 포인트에 대한 HTTP request-요청을 만드는 데모에는 [Axios](https://github.com/mzabriskie/axios)를 사용하겠습니다.
 
 > {tip} If you don't want to implement the entire client management frontend yourself, you can use the [frontend quickstart](#frontend-quickstart) to have a fully functional frontend in a matter of minutes.
 
+> {tip} 만약 클라이언트 관리용 전체 프론트 엔드를 자체적으로 구현하는 것을 원하지 않는다면, [빠르게 프론트 엔드 시작하기](#frontend-quickstart)를 사용하여, 프론트엔드 전체 기능을 구성할 수 있습니다.
+
+#### `GET /oauth/clients`
 #### `GET /oauth/clients`
 
 This route returns all of the clients for the authenticated user. This is primarily useful for listing all of the user's clients so that they may edit or delete them:
+
+이 라우트는 인증된 사용자의 모든 클라이언트들을 반환합니다. 이는 주로 사용자의 모든 클라이언트 목록을 표시하고 수정이나 삭제하고자 할 때 유용합니다: 
 
     axios.get('/oauth/clients')
         .then(response => {
@@ -216,10 +303,15 @@ This route returns all of the clients for the authenticated user. This is primar
         });
 
 #### `POST /oauth/clients`
+#### `POST /oauth/clients`
 
 This route is used to create new clients. It requires two pieces of data: the client's `name` and a `redirect` URL. The `redirect` URL is where the user will be redirected after approving or denying a request for authorization.
 
+이 라우트는 새로운 클라이언트를 생성하는데 사용됩니다. 여기에는 두개의 데이터가 필요합니다: 클라이언트의 `name`과 한개의 `redirect` URL입니다. `redirect` URL은 request-요청에 대한 접근이 승인 또는 거부된 뒤에 사용자가 리다이렉션 되는 곳입니다.
+
 When a client is created, it will be issued a client ID and client secret. These values will be used when requesting access tokens from your application. The client creation route will return the new client instance:
+
+클라이언트가 생성되면, 클라이언트의 ID 와 암호키가 발급됩니다. 이 정보들은 어플리케이션에서 엑세스 토큰을 요청할 때 사용됩니다. 클라이언트 생성 라우트는 그 결과로 새로운 클라이언트의 인스턴스를 반환합니다:
 
     const data = {
         name: 'Client Name',
@@ -235,8 +327,11 @@ When a client is created, it will be issued a client ID and client secret. These
         });
 
 #### `PUT /oauth/clients/{client-id}`
+#### `PUT /oauth/clients/{client-id}`
 
 This route is used to update clients. It requires two pieces of data: the client's `name` and a `redirect` URL. The `redirect` URL is where the user will be redirected after approving or denying a request for authorization. The route will return the updated client instance:
+
+이 라우트는 새로운 클라이언트를 생성하는데 사용됩니다. 여기에는 두개의 데이터가 필요합니다: 클라이언트의 `name`과 한개의 `redirect` URL입니다. `redirect` URL은 request-요청에 대한 접근이 승인 또는 거부된 뒤에 사용자가 리다이렉션 되는 곳입니다. 이 라우트는 수정된 클라이언트의 인스턴스를 반환합니다:
 
     const data = {
         name: 'New Client Name',
@@ -252,8 +347,11 @@ This route is used to update clients. It requires two pieces of data: the client
         });
 
 #### `DELETE /oauth/clients/{client-id}`
+#### `DELETE /oauth/clients/{client-id}`
 
 This route is used to delete clients:
+
+이 라우트는 클라이언트를 삭제할 때 사용됩니다:
 
     axios.delete('/oauth/clients/' + clientId)
         .then(response => {
@@ -262,10 +360,14 @@ This route is used to delete clients:
 
 <a name="requesting-tokens"></a>
 ### Requesting Tokens
+### 토큰 요청
 
 #### Redirecting For Authorization
+#### 권한승인을 위한 리다이렉팅
 
 Once a client has been created, developers may use their client ID and secret to request an authorization code and access token from your application. First, the consuming application should make a redirect request to your application's `/oauth/authorize` route like so:
+
+클라이언트가 생성되고 나서, 개발자는 클라이언트 ID와 암호키를를 사용하여 권한 승인을 요청하고 어플리케이션의 토큰에 엑세스 할 수 있습니다. 먼저 API를 사용하는 어플리케이션이 다음의 `/oauth/authorize` 라우트로 리다이렉트 요청을 하도록 만들어야 합니다:
 
     Route::get('/redirect', function () {
         $query = http_build_query([
@@ -280,17 +382,27 @@ Once a client has been created, developers may use their client ID and secret to
 
 > {tip} Remember, the `/oauth/authorize` route is already defined by the `Passport::routes` method. You do not need to manually define this route.
 
+> {tip} `/oauth/authorize` 라우트는 `Passport::routes` 메소드에서 이미 정의되어 있습니다. 이 라우트를 수동으로 등록할 필요가 없습니다.
+
 #### Approving The Request
+#### Request-요청 승인
 
 When receiving authorization requests, Passport will automatically display a template to the user allowing them to approve or deny the authorization request. If they approve the request, they will be redirected back to the `redirect_uri` that was specified by the consuming application. The `redirect_uri` must match the `redirect` URL that was specified when the client was created.
 
+권한 승인 요청을 받으면, Passport는 자동으로 사용자가 템플릿을 표시하여 승인 요청을 수락하거나 거부할 수 있게 합니다. 요청이 승인되면, 어플리케이션에 의해서 지정된 `redirect_uri` 로 리다이렉션 됩니다. `redirect_uri` 는 클라이언트가 생성될 때 지정되었던 `redirect` URL과 일치해야 합니다.
+
 If you would like to customize the authorization approval screen, you may publish Passport's views using the `vendor:publish` Artisan command. The published views will be placed in `resources/views/vendor/passport`:
+
+권한 승인 화면을 커스터마이징 하고싶다면, `vendor:publish` 아티즌 명령어를 사용하여 Passport 뷰 파일을 퍼블리싱할 수 있습니다. 퍼블리싱된 뷰파일은 `resources/views/vendor/passport` 디렉토리에 위치합니다. 이제 이를 수정하면 됩니다:
 
     php artisan vendor:publish --tag=passport-views
 
 #### Converting Authorization Codes To Access Tokens
+#### 승인 코드를 엑세스 토큰으로 변환하기
 
 If the user approves the authorization request, they will be redirected back to the consuming application. The consumer should then issue a `POST` request to your application to request an access token. The request should include the authorization code that was issued by your application when the user approved the authorization request. In this example, we'll use the Guzzle HTTP library to make the `POST` request:
+
+사용자가 승인 요청을 수락하면, 사용중인 어플리케이션으로 리다이렉션됩니다. 고객은 엑세스 토큰을 획득하기 위해서 여러분의 어플리케이션으로 `POST` 요청을 보내야 합니다. 요청-request에는 사용자의 승인 요청을 통해서 어플리케이션에서 발급된 승인코드가 포함되어 있어야 합니다. 이 예제에서 Guzzle Http 라이브러리를 사용하여 `POST` 요청-request를 만들어 보겠습니다:
 
     Route::get('/callback', function (Request $request) {
         $http = new GuzzleHttp\Client;
@@ -310,12 +422,19 @@ If the user approves the authorization request, they will be redirected back to 
 
 This `/oauth/token` route will return a JSON response containing `access_token`, `refresh_token`, and `expires_in` attributes. The `expires_in` attribute contains the number of seconds until the access token expires.
 
+`/oauth/token` 라우트는 `access_token`, `refresh_token`, 그리고 `expires_in`을 포함하는 JSON 응답-response를 반환합니다. `expires_in` 속성은 엑세스 토큰이 만료되기까지의 (초)를 가지고 있습니다.
+
 > {tip} Like the `/oauth/authorize` route, the `/oauth/token` route is defined for you by the `Passport::routes` method. There is no need to manually define this route.
+
+> {tip} `/oauth/authorize` 라우트와 같이 `/oauth/token` 라우트는 `Passport::routes` 메소드에 의해서 정의됩니다. 이 라우트를 수동으로 등록할 필요가 없습니다.
 
 <a name="refreshing-tokens"></a>
 ### Refreshing Tokens
+### 토큰 갱신하기
 
 If your application issues short-lived access tokens, users will need to refresh their access tokens via the refresh token that was provided to them when the access token was issued. In this example, we'll use the Guzzle HTTP library to refresh the token:
+
+어플리케이션에서 사용기간이 짧은 엑세스 토큰을 발급한다면, 사용자는 엑세스 토큰을 발급할 때 제공된 리프레쉬 토큰을 사용하여 엑세스 토큰을 새롭게 갱신해야 합니다. 이 예제에서 Guzzle HTTP 라이브러리르 사용하여 토큰을 갱신해보겠습니다:
 
     $http = new GuzzleHttp\Client;
 
@@ -333,22 +452,33 @@ If your application issues short-lived access tokens, users will need to refresh
 
 This `/oauth/token` route will return a JSON response containing `access_token`, `refresh_token`, and `expires_in` attributes. The `expires_in` attribute contains the number of seconds until the access token expires.
 
+`/oauth/token` 라우트는 `access_token`, `refresh_token`, 그리고 `expires_in`을 포함하는 JSON 응답-response를 반환합니다. `expires_in` 속성은 엑세스 토큰이 만료되기까지의 (초)를 가지고 있습니다.
+
 <a name="password-grant-tokens"></a>
 ## Password Grant Tokens
+## 패스워드 Grant 토큰
 
 The OAuth2 password grant allows your other first-party clients, such as a mobile application, to obtain an access token using an e-mail address / username and password. This allows you to issue access tokens securely to your first-party clients without requiring your users to go through the entire OAuth2 authorization code redirect flow.
 
+OAuth2 패스워드 그랜트는 모바일 어플리케이션과 같은 여러분의 다른 클라이언트가 이메일 주소와 / 사용자 이름 및 암호를 사용하여 엑세스 토큰을 획득할 수 있도록 해줍니다. 이를 통해 OAuth2의 승인 코드 리다이렉션 request를 필요로 하지 않고도 엑세스 토큰을 안전하게 발급할 수 있도록 해줍니다.
+
 <a name="creating-a-password-grant-client"></a>
 ### Creating A Password Grant Client
+### 패스워드 Grant 클라이언트 생성하기
 
 Before your application can issue tokens via the password grant, you will need to create a password grant client. You may do this using the `passport:client` command with the `--password` option. If you have already run the `passport:install` command, you do not need to run this command:
+
+패스워드 grant를 통해서 어플리케이션에서 토큰을 발급하기 전에, 패스워드 grant 클라이언트를 생성해야 합니다. `passport:client` 명령어에 `--password` 옵션을 지정하여 이를 생성할 수 있습니다. `passport:install` 명령어를 이미 실행했다면, 이 명령어를 실행할 필요는 없습니다:
 
     php artisan passport:client --password
 
 <a name="requesting-password-grant-tokens"></a>
 ### Requesting Tokens
+### 토큰 요청하기
 
 Once you have created a password grant client, you may request an access token by issuing a `POST` request to the `/oauth/token` route with the user's email address and password. Remember, this route is already registered by the `Passport::routes` method so there is no need to define it manually. If the request is successful, you will receive an `access_token` and `refresh_token` in the JSON response from the server:
+
+패스워드 grant 클라이언트가 생성되면, 사용자의 이메일과 패스워드와 함께 `/oauth/token` 라우트에 엑세스 토큰 발급 `POST` request-요청을 보낼 수 있습니다. 기억할점은, 이 라우트는 `Passport::routes`메소드에 의해서 이미 등록되어 있기 때문에, 직접 라우트를 등록할 필요가 없다는 것입니다. 요청-request가 성공적이라면, 서버로 부터 `access_token` 과 `refresh_token` 가 담긴 JSON 응답-response를 받습니다:
 
     $http = new GuzzleHttp\Client;
 
@@ -367,10 +497,15 @@ Once you have created a password grant client, you may request an access token b
 
 > {tip} Remember, access tokens are long-lived by default. However, you are free to [configure your maximum access token lifetime](#configuration) if needed.
 
+> {tip} 엑세스 토큰은 기본적으로 오랜시간 지속됩니다. 그렇지만 필요하다면, 자유롭게 [엑세스 토큰 지속시간을 설정](#configuration) 할 수 있습니다.
+
 <a name="requesting-all-scopes"></a>
 ### Requesting All Scopes
+### 모든 범위에 대하여 요청하기
 
 When using the password grant, you may wish to authorize the token for all of the scopes supported by your application. You can do this by requesting the `*` scope. If you request the `*` scope, the `can` method on the token instance will always return `true`. This scope may only be assigned to a token that is issued using the `password` grant:
+
+패스워드 grant를 사용할 때, 여러분은 어플리케이션에서 지원하는 모든 범위의 사용이 가능한 토큰을 승인 하고자 할수 있습니다. 이렇하려면 `*` 범위로 요청하면 됩니다. `*` 범위를 요청하면 토큰 인스턴스의 `can` 메소드가 항상 `true` 를 반환할 것입니다. 이 범위는 `password` grant를 통해 발행 된 토큰에만 할당하는 것이 좋습니다:
 
     $response = $http->post('http://your-app.com/oauth/token', [
         'form_params' => [
@@ -385,8 +520,11 @@ When using the password grant, you may wish to authorize the token for all of th
 
 <a name="implicit-grant-tokens"></a>
 ## Implicit Grant Tokens
+## 묵시적 grant 토큰
 
 The implicit grant is similar to the authorization code grant; however, the token is returned to the client without exchanging an authorization code. This grant is most commonly used for JavaScript or mobile applications where the client credentials can't be securely stored. To enable the grant, call the `enableImplicitGrant` method in your `AuthServiceProvider`:
+
+묵시적 grant는 승인 코드 grant와 비슷합니다. 그렇지만, 클라이언트에서 반환되는 토큰은 승인 코드를 교환하지 않습니다. 이 grant는 클라이언트 자격증명을 안전하게 저장할 수 없는 자바스크립트 또는 모바일 어플리케이션에서 가장 일반적으로 사용됩니다. grant를 활성화하려면, `AuthServiceProvider` 에서 `enableImplicitGrant` 메소드를 호출하면 됩니다:
 
     /**
      * Register any authentication / authorization services.
@@ -404,6 +542,8 @@ The implicit grant is similar to the authorization code grant; however, the toke
 
 Once a grant has been enabled, developers may use their client ID to request an access token from your application. The consuming application should make a redirect request to your application's `/oauth/authorize` route like so:
 
+grant가 활성화 되면, 개발자는 어플리케이션에서 엑세스 토큰을 요청하는데 클라이언트 ID를 사용할 수 있습니다. 이를 처리하는 어플리케이션은 다음처럼 리다이렉트 요청-request를 여러분의 어플리케이션의 `/oauth/authorize` 라우트로 보내야 합니다:
+
     Route::get('/redirect', function () {
         $query = http_build_query([
             'client_id' => 'client-id',
@@ -417,10 +557,15 @@ Once a grant has been enabled, developers may use their client ID to request an 
 
 > {tip} Remember, the `/oauth/authorize` route is already defined by the `Passport::routes` method. You do not need to manually define this route.
 
+> {tip} `/oauth/authorize` 라우트는 `Passport::routes` 메소드에 의해서 정의된다는 것을 기억하십시오. 이 라우트를 수동으로 등록할 필요가 없습니다.
+
 <a name="client-credentials-grant-tokens"></a>
 ## Client Credentials Grant Tokens
+## 클라이언트의 자격증명을 위한 Grant 토큰
 
 The client credentials grant is suitable for machine-to-machine authentication. For example, you might use this grant in a scheduled job which is performing maintenance tasks over an API. To use this method you first need to add new middleware to your `$routeMiddleware` in `app/Http/Kernel.php`:
+
+클라이언트의 자격증명을 위한 Grant 는 시스템간의 인증에 적합합니다. 예를 들어, API를 통해서 관리 작업을 수행하도록 예약된 스케줄링 job에서 이 grant를 사용할 수 있습니다. 이 메소드를 사용히기 위해서는 먼저 `app/Http/Kernel.php` 파일의 `$routeMiddleware` 에 새로운 미들웨어를 추가해야합니다:
 
     use Laravel\Passport\Http\Middleware\CheckClientCredentials;
 
@@ -430,11 +575,15 @@ The client credentials grant is suitable for machine-to-machine authentication. 
 
 Then attach this middleware to a route:
 
+그 다음 이 미들웨어를 라우트에 추가하십시오:
+
     Route::get('/user', function(Request $request) {
         ...
     })->middleware('client');
 
 To retrieve a token, make a request to the `oauth/token` endpoint:
+
+토큰을 획득하려면, `oauth/token` 으로 request를 연결하십시오:
 
     $guzzle = new GuzzleHttp\Client;
 
@@ -451,22 +600,33 @@ To retrieve a token, make a request to the `oauth/token` endpoint:
 
 <a name="personal-access-tokens"></a>
 ## Personal Access Tokens
+## 개인용 엑세스 토큰
 
 Sometimes, your users may want to issue access tokens to themselves without going through the typical authorization code redirect flow. Allowing users to issue tokens to themselves via your application's UI can be useful for allowing users to experiment with your API or may serve as a simpler approach to issuing access tokens in general.
 
+때로는, 사용자가 일반적인 승인 코드 리다이렉션 플로우를 거치지 않고 엑세스 토큰을 발급하기를 원할 수도 있습니다. 사용자가 어플리케이션의 UI를 통해 자신에게 토큰을 발행 할 수 있게 하면, 사용자가 API를 테스트해 볼 수도 있고, 일반적으로 액세스 토큰을 발행하기 위한 더 간단한 방법으로도 사용할 수 있습니다.
+
 > {note} Personal access tokens are always long-lived. Their lifetime is not modified when using the `tokensExpireIn` or `refreshTokensExpireIn` methods.
+
+> {note} 개인용 엑세스 토큰은 기본적으로 오랜시간 지속됩니다. `tokensExpireIn` 또는 `refreshTokensExpireIn` 메소드를 사용하는 경우 지속시간이 수정되지 않습니다.
 
 <a name="creating-a-personal-access-client"></a>
 ### Creating A Personal Access Client
+### 개인용 엑세스 클라이언트 생성하기
 
 Before your application can issue personal access tokens, you will need to create a personal access client. You may do this using the `passport:client` command with the `--personal` option. If you have already run the `passport:install` command, you do not need to run this command:
+
+어플리케이션이 개인용 엑세스 토큰을 발급 할 수 있도록 하기 전에, 개인용 엑세스 클라이언트를 생성해야 합니다. 이렇게 하려면 `passport:client` 명령어에 `--personal` 옵션을 사용하면 됩니다. 만약 이미 `passport:install`명령어를 실행했다면, 이 명령어를 실행할 필요는 없습니다:
 
     php artisan passport:client --personal
 
 <a name="managing-personal-access-tokens"></a>
 ### Managing Personal Access Tokens
+### 개인용 엑세스 토큰 관리하기
 
 Once you have created a personal access client, you may issue tokens for a given user using the `createToken` method on the `User` model instance. The `createToken` method accepts the name of the token as its first argument and an optional array of [scopes](#token-scopes) as its second argument:
+
+개인용 엑세스 클라이언트를 생성하고 나면, `User` 모델 인스턴스의 `createToken` 메소드를 사용하여 주어진 사용자를 위한 토큰을 발급할 수 있습니다. `createToken` 메소드는 토큰의 이름을 첫번째 인자로, [범위](#token-scopes)의 배열을 선택적으로 두번째 인자로 받습니다.
 
     $user = App\User::find(1);
 
@@ -477,14 +637,22 @@ Once you have created a personal access client, you may issue tokens for a given
     $token = $user->createToken('My Token', ['place-orders'])->accessToken;
 
 #### JSON API
+#### JSON API
 
 Passport also includes a JSON API for managing personal access tokens. You may pair this with your own frontend to offer your users a dashboard for managing personal access tokens. Below, we'll review all of the API endpoints for managing personal access tokens. For convenience, we'll use [Axios](https://github.com/mzabriskie/axios) to demonstrate making HTTP requests to the endpoints.
 
+passport는 이미 개인용 엑세스 토큰을 관리하는 JSON APIf를 포함하고 있습니다. 이 API와 함께 여러분의 고유한 프론트 엔드를 구성하여 사용자에게 개인용 엑세스 토큰을 관리할 수 있는 대시보드를 제공할 수 있습니다. 아래에서 개인용 엑세스 토큰을 관리하는 모든 API 엔드포인트를 확인해보겠습니다. 편의를 위해서, 엔드포인트에 대한 HTTP request-요청을 만드는 데모에는 [Axios](https://github.com/mzabriskie/axios)를 사용하겠습니다.
+
 > {tip} If you don't want to implement the personal access token frontend yourself, you can use the [frontend quickstart](#frontend-quickstart) to have a fully functional frontend in a matter of minutes.
 
+> {tip} 만약 개인용 엑세스 토큰 관리용 전체 프론트 엔드를 자체적으로 구현하는 것을 원하지 않는다면, [빠르게 프론트 엔드 시작하기](#frontend-quickstart)를 사용하여, 프론트엔드 전체 기능을 구성할 수 있습니다.
+
+#### `GET /oauth/scopes`
 #### `GET /oauth/scopes`
 
 This route returns all of the [scopes](#token-scopes) defined for your application. You may use this route to list the scopes a user may assign to a personal access token:
+
+이 라우트는 어플리케이션에서 정의된 모든 [스코프-범위](#token-scopes)를 반환합니다. 이 라우트를 사용자가 개인용 엑세스 토큰에 할당된 범위를 나열하는데 사용할 수 있습니다:
 
     axios.get('/oauth/scopes')
         .then(response => {
@@ -492,8 +660,11 @@ This route returns all of the [scopes](#token-scopes) defined for your applicati
         });
 
 #### `GET /oauth/personal-access-tokens`
+#### `GET /oauth/personal-access-tokens`
 
 This route returns all of the personal access tokens that the authenticated user has created. This is primarily useful for listing all of the user's tokens so that they may edit or delete them:
+
+이 라우트는 인증된 사용자가 생성한 모든 개인용 엑세스 토큰을 반환합니다. 모든 사용자 토큰을 목록을 확인하는데 유용하여, 주로 이를 수정하거나, 삭제할 수 있습니다:
 
     axios.get('/oauth/personal-access-tokens')
         .then(response => {
@@ -501,8 +672,11 @@ This route returns all of the personal access tokens that the authenticated user
         });
 
 #### `POST /oauth/personal-access-tokens`
+#### `POST /oauth/personal-access-tokens`
 
 This route creates new personal access tokens. It requires two pieces of data: the token's `name` and the `scopes` that should be assigned to the token:
+
+이 라우트는 새로운 개인용 엑세스 토큰을 생성합니다. 여기에는 두개의 데이터가 필요합니다: 토큰의 `name` 과 토큰에 할당되는 `scopes` 입니다:
 
     const data = {
         name: 'Token Name',
@@ -518,18 +692,25 @@ This route creates new personal access tokens. It requires two pieces of data: t
         });
 
 #### `DELETE /oauth/personal-access-tokens/{token-id}`
+#### `DELETE /oauth/personal-access-tokens/{token-id}`
 
 This route may be used to delete personal access tokens:
+
+이 라우트는 개인용 엑세스 토큰을 삭제하는데 사용됩니다:
 
     axios.delete('/oauth/personal-access-tokens/' + tokenId);
 
 <a name="protecting-routes"></a>
 ## Protecting Routes
+## 라우트 보호하기
 
 <a name="via-middleware"></a>
 ### Via Middleware
+### 미들웨어를 통해서
 
 Passport includes an [authentication guard](/docs/{{version}}/authentication#adding-custom-guards) that will validate access tokens on incoming requests. Once you have configured the `api` guard to use the `passport` driver, you only need to specify the `auth:api` middleware on any routes that require a valid access token:
+
+Passport는 유입되는 request-요청에 대해서 엑세스 토큰을 검증하는 [사용자 승인 guard]((/docs/{{version}}/authentication#adding-custom-guards)를 포함하고 있습니다. `api` guard가 `passport` 드라이버를 사용하도록 설정하였다면, 엑세스 토큰 검사가 필요한 라우트에 `auth:api` 미들웨어를 지정하기만 하면 됩니다:
 
     Route::get('/user', function () {
         //
@@ -537,8 +718,11 @@ Passport includes an [authentication guard](/docs/{{version}}/authentication#add
 
 <a name="passing-the-access-token"></a>
 ### Passing The Access Token
+### 엑세스 토큰 전달하기
 
 When calling routes that are protected by Passport, your application's API consumers should specify their access token as a `Bearer` token in the `Authorization` header of their request. For example, when using the Guzzle HTTP library:
+
+Passport에 의해서 보호되는 라우트를 호출할 때, 어플리케이션의 API 사용자는 그들의 요청-request의 `Authorization` 헤더에 `Bearer` 토큰으로 엑세스 토큰을 지정해야 합니다. 예를 들어 Guzzle HTTP 라이브러리를 사용해보겠습니다:
 
     $response = $client->request('GET', '/api/user', [
         'headers' => [
@@ -549,13 +733,19 @@ When calling routes that are protected by Passport, your application's API consu
 
 <a name="token-scopes"></a>
 ## Token Scopes
+## 토큰 스코프(범위)
 
 <a name="defining-scopes"></a>
 ### Defining Scopes
+### 스코프 정의하기
 
 Scopes allow your API clients to request a specific set of permissions when requesting authorization to access an account. For example, if you are building an e-commerce application, not all API consumers will need the ability to place orders. Instead, you may allow the consumers to only request authorization to access order shipment statuses. In other words, scopes allow your application's users to limit the actions a third-party application can perform on their behalf.
 
+스코프는 계정에 대한 엑세스 승인을 요청할 때, 여러분의 API 클라이언트가 제한된 권한을 지정하여 요청하도록 합니다. 예를 들어, e-커머스 어플리케이션을 구성한다면, 전체 API 사용자에게 주문을 할 수 있는 권한을 줄 필요는 없을것입니다. 대신에, 사용자에게 주문 배송상황에 엑세스 할 수 있는 권한을 주면 됩니다. 다시 말해 스코프는 여러분의 어플리케이션 사용자가 써드파티 어플리케이션을 통해서 실행할 수 있는 액션을 제한할 수 있습니다.
+
 You may define your API's scopes using the `Passport::tokensCan` method in the `boot` method of your `AuthServiceProvider`. The `tokensCan` method accepts an array of scope names and scope descriptions. The scope description may be anything you wish and will be displayed to users on the authorization approval screen:
+
+API의 범위(scope)는 `AuthServiceProvider` 의 `boot` 메소드에서 `Passport:tokensCan` 메소드를 사용하여 정의할 수 있습니다. `tokensCan` 메소드는 스코프의 이름과, 설명에 대한 배열을 인자로 받습니다. 스코프 설명은 권한 승인 페이지에서 사용자에게 보여주려는 어떠한 내용도 가능합니다:
 
     use Laravel\Passport\Passport;
 
@@ -566,10 +756,14 @@ You may define your API's scopes using the `Passport::tokensCan` method in the `
 
 <a name="assigning-scopes-to-tokens"></a>
 ### Assigning Scopes To Tokens
+### 토큰에 스코프 할당하기
 
 #### When Requesting Authorization Codes
+#### 승인 코드를 요청할 때
 
 When requesting an access token using the authorization code grant, consumers should specify their desired scopes as the `scope` query string parameter. The `scope` parameter should be a space-delimited list of scopes:
+
+승인 코드 grant를 사용하여 엑세스 토큰을 요청할 때, 사용자는 `scope` 쿼리 스트링 인자를 통해서 원하는 scope-범위를 지정해야 합니다. `scope` 파라미터는 scope-범위의 목록들을 공백으로 구분한 내용이어야 합니다:
 
     Route::get('/redirect', function () {
         $query = http_build_query([
@@ -583,38 +777,53 @@ When requesting an access token using the authorization code grant, consumers sh
     });
 
 #### When Issuing Personal Access Tokens
+#### 개인용 엑세스 토큰 발급할 때
 
 If you are issuing personal access tokens using the `User` model's `createToken` method, you may pass the array of desired scopes as the second argument to the method:
+
+`User` 모델의 `createToken` 메소드를 사용하여 개인용 엑세스 토큰을 발급하고자 한다면, 메소드의 두번째 인자로 원하는 scope를 배열로 전달할 수 있습니다:
 
     $token = $user->createToken('My Token', ['place-orders'])->accessToken;
 
 <a name="checking-scopes"></a>
 ### Checking Scopes
+### Scope 확인하기
 
 Passport includes two middleware that may be used to verify that an incoming request is authenticated with a token that has been granted a given scope. To get started, add the following middleware to the `$routeMiddleware` property of your `app/Http/Kernel.php` file:
+
+Passport 는 유입되는 request-요청이 주어진 코드에 의해서 권한이 확인된 토큰에 의해서 승인되었는지 확인할 수 있는 두개의 미들웨어를 포함하고 있습니다. 이를 사용하려면 `app/Http/Kernel.php` 파일의 `$routeMiddleware` 속성에 다음과 같이 정의해야 합니다:
 
     'scopes' => \Laravel\Passport\Http\Middleware\CheckScopes::class,
     'scope' => \Laravel\Passport\Http\Middleware\CheckForAnyScope::class,
 
 #### Check For All Scopes
+#### 전체 Scope-범위 확인하기
 
 The `scopes` middleware may be assigned to a route to verify that the incoming request's access token has *all* of the listed scopes:
+
+`scopes` 미들웨어는 라우트에 할당하여 유입되는 request-요청의 엑세스 토큰이 *전체* scope인지 확인하는데 사용할 수 있습니다:
 
     Route::get('/orders', function () {
         // Access token has both "check-status" and "place-orders" scopes...
     })->middleware('scopes:check-status,place-orders');
 
 #### Check For Any Scopes
+#### 특정 범위 확인하기
 
 The `scope` middleware may be assigned to a route to verify that the incoming request's access token has *at least one* of the listed scopes:
+
+`scope` 미들웨어는 라우트에 할당하여 유입되는 request-요청의 엑세스 토큰이 *최소한 하나*의 scope에 해당하는지 확인하는데 사용할 수 있습니다:
 
     Route::get('/orders', function () {
         // Access token has either "check-status" or "place-orders" scope...
     })->middleware('scope:check-status,place-orders');
 
 #### Checking Scopes On A Token Instance
+#### 토큰 인스턴스에서 scope-범위 확인하기
 
 Once an access token authenticated request has entered your application, you may still check if the token has a given scope using the `tokenCan` method on the authenticated `User` instance:
+
+엑세스 토큰이 인증된 request-요청이 어플리케이션에 전달되면, 인증된 `User` 인스턴스의 `tokenCan` 메소드를 사용하여 토큰이 주어진 scope에 해당하는지 확인할 수 있습니다:
 
     use Illuminate\Http\Request;
 
@@ -626,10 +835,15 @@ Once an access token authenticated request has entered your application, you may
 
 <a name="consuming-your-api-with-javascript"></a>
 ## Consuming Your API With JavaScript
+## 자바스크립트로 API 사용하기
 
 When building an API, it can be extremely useful to be able to consume your own API from your JavaScript application. This approach to API development allows your own application to consume the same API that you are sharing with the world. The same API may be consumed by your web application, mobile applications, third-party applications, and any SDKs that you may publish on various package managers.
 
+API를 구성할 때 자바스크립트 어플리케이션에서 여러분의 API를 사용할 수 있으면, 매우 편리합니다. 이런 API 개발 방식을 사용하면 여러분의 어플리케이션이 전세계로 공유되는 것과 동일한 API를 사용할 수 있게 됩니다. 웹 어플리케이션, 모바일 어플리케이션, 써드파티 어플리케이션 및 다양한 패키지 관리자를 통해 퍼블리싱 할 수 있는 SDK에서 동일한 API를 사용할 수 있습니다.
+
 Typically, if you want to consume your API from your JavaScript application, you would need to manually send an access token to the application and pass it with each request to your application. However, Passport includes a middleware that can handle this for you. All you need to do is add the `CreateFreshApiToken` middleware to your `web` middleware group:
+
+일반적으로, 여러분의 API를 자바스크립트 어플리케이션에서 사용하고자 한다면, 어플리케이션에 엑세스 토큰을 수동으로 보내고, 매번 어플리케이션에 요청-request 할때 마다 이 토큰을 전달해야 합니다. 그렇지만 Passport는 이미 이를 처리하는 미들웨어를 포함하고 있습니다. 여러분에게 필요한 것은 `web` 미들웨어 그룹에 `CreateFreshApiToken` 미들웨어를 추가하는 것 뿐입니다:
 
     'web' => [
         // Other middleware...
@@ -638,6 +852,8 @@ Typically, if you want to consume your API from your JavaScript application, you
 
 This Passport middleware will attach a `laravel_token` cookie to your outgoing responses. This cookie contains an encrypted JWT that Passport will use to authenticate API requests from your JavaScript application. Now, you may make requests to your application's API without explicitly passing an access token:
 
+이 Passport 미들웨어는 `laravel_token` 쿠키를 반환되는 응답-response에 덧붙입니다. 이 쿠키는 Passport 가 여러분의 자바스크립트 어플리케이션에서 인증 API 요청-request에서 사용할 암호화된 JWT를 가지고 있습니다. 이제 액세스 토큰을 명시적으로 전달하지 않고도 여러분의 어플리케이션에 API에 요청-request를 만들 수 있습니다:
+
     axios.get('/api/user')
         .then(response => {
             console.log(response.data);
@@ -645,16 +861,23 @@ This Passport middleware will attach a `laravel_token` cookie to your outgoing r
 
 When using this method of authentication, the default Laravel JavaScript scaffolding instructs Axios to always send the `X-CSRF-TOKEN` and `X-Requested-With` headers. However, you should be sure to include your CSRF token in a [HTML meta tag](/docs/{{version}}/csrf#csrf-x-csrf-token):
 
+이 인증 메소드를 사용할 때, 라라벨에서 기본적으로 제공하는 자바스크립트 스캐폴딩은 Axios가 항상 `X-CSRF-TOKEN`와  `X-Requested-With` 헤더를 전송하도록 합니다. 그렇지만, [HTML meta tag](/docs/{{version}}/csrf#csrf-x-csrf-token)에 CSRF 토큰이 들어 있어야 합니다.
+
     window.axios.defaults.headers.common = {
         'X-Requested-With': 'XMLHttpRequest',
     };
 
 > {note} If you are using a different JavaScript framework, you should make sure it is configured to send the `X-CSRF-TOKEN` and `X-Requested-With` headers with every outgoing request.
 
+> {note} 다른 자바스크립트 프레임워크를 사용한다면, 모든 요청-request에 대해서 `X-CSRF-TOKEN` 와 `X-Requested-With` 헤더를 전달하도록 설정해야합니다.
+
 <a name="events"></a>
 ## Events
+## 이벤트
 
 Passport raises events when issuing access tokens and refresh tokens. You may use these events to prune or revoke other access tokens in your database. You may attach listeners to these events in your application's `EventServiceProvider`:
+
+Passport 는 엑세스 토큰과 리프레쉬 토큰을 발급할 때 이벤트를 발생시킵니다. 이 이벤트를 사용하여 데이터베이스의 다른 액세스 토큰을 제거하거나 취소 할 수 있습니다. 여러분의 어플리케이션의 `EventServiceProvider` 안에서 이벤트 리스너를 추가할 수 있습니다:
 
 ```php
 /**
@@ -675,8 +898,11 @@ protected $listen = [
 
 <a name="testing"></a>
 ## Testing
+## 테스팅
 
 Passport's `actingAs` method may be used to specify the currently authenticated user as well as its scopes. The first argument given to the `actingAs` method is the user instance and the second is an array of scopes that should be granted to the user's token:
+
+Passport의 `actionAs` 메소드는 현재 인증된 사용자를 지정하는데 사용할 수 있습니다. `actionAs` 메소드에 전달되는 첫번째 인자는 사용자 인스턴스이고, 두번째 인자는 사용자의 토큰에 허용된 스코프 배열입니다:
 
     public function testServerCreation()
     {

--- a/kr/socialite.md
+++ b/kr/socialite.md
@@ -1,32 +1,52 @@
 # Laravel Socialite
+# 라라벨 소셜라이트(소셜로그인)
 
 - [Introduction](#introduction)
+- [소개하기](#introduction)
 - [Installation](#installation)
+- [설치하기](#installation)
 - [Configuration](#configuration)
+- [설정하기](#configuration)
 - [Routing](#routing)
+- [라우팅](#routing)
 - [Optional Parameters](#optional-parameters)
+- [옵션 파라미터](#optional-parameters)
 - [Access Scopes](#access-scopes)
+- [엑세스 스코프](#access-scopes)
 - [Stateless Authentication](#stateless-authentication)
+- [상태를 유지하지 않는 인증](#stateless-authentication)
 - [Retrieving User Details](#retrieving-user-details)
+- [사용자 상세정보 조회하기](#retrieving-user-details)
 
 <a name="introduction"></a>
 ## Introduction
+## 소개하기
 
 In addition to typical, form based authentication, Laravel also provides a simple, convenient way to authenticate with OAuth providers using [Laravel Socialite](https://github.com/laravel/socialite). Socialite currently supports authentication with Facebook, Twitter, LinkedIn, Google, GitHub and Bitbucket.
 
+일반적인 Form을 기반으로한 인증에 더해서, 라라벨은 [라라벨 소셜라이트-Socialite](https://github.com/laravel/socialite)를 사용하여 OAuth 인증을 간단하고 편리하게 제공합니다. Socialite는 현재 페이스북, 트위터, 링크드인, 구글, 깃허브 그리고 Bitbucket을 기본적으로 지원하고 있습니다.
+
 > {tip} Adapters for other platforms are listed at the community driven [Socialite Providers](https://socialiteproviders.github.io/) website.
+
+> {tip} 다른 플랫폼을 위한 어댑터는 커뮤니티에서 주도하는 [Socialite Providers](https://socialiteproviders.github.io/) 웹사이트에서 확인할 수 있습니다. (한국 사용자들이 많이 사용하는 카카오, 네이버, 라인등도 제공됩니다)
 
 <a name="installation"></a>
 ## Installation
+## 설치하기
 
 To get started with Socialite, use Composer to add the package to your project's dependencies:
+
+Socialite를 사용하기 위해서는 컴포저를 사용하여 프로젝트에 의존성 패키지를 추가하십시오:
 
     composer require laravel/socialite
 
 <a name="configuration"></a>
 ## Configuration
+## 설정하기
 
 Before using Socialite, you will also need to add credentials for the OAuth services your application utilizes. These credentials should be placed in your `config/services.php` configuration file, and should use the key `facebook`, `twitter`, `linkedin`, `google`, `github` or `bitbucket`, depending on the providers your application requires. For example:
+
+Socialite를 사용하기 전에, 어플리케이션에서 사용할 OAuth서비스의 인증 정보를 추가해야합니다. 이 인증 정보는 `config/services.php` 설정 파일에서 추가하면 되며, 어플리케이션에서 필요한 서비스에 따라서, `facebook`, `twitter`, `linkedin`, `google`, `github` 그리고 `bitbucket` 처럼 사용되야 합니다. 다음의 예제를 보십시오:
 
     'github' => [
         'client_id' => env('GITHUB_CLIENT_ID'),         // Your GitHub Client ID
@@ -36,10 +56,15 @@ Before using Socialite, you will also need to add credentials for the OAuth serv
 
 > {tip} If the `redirect` option contains a relative path, it will automatically be resolved to a fully qualified URL.
 
+> {tip} `redirect` 옵션값에 상대경로가 포함된경우, 자동으로 Full URL로 인식됩니다.
+
 <a name="routing"></a>
 ## Routing
+## 라우팅
 
 Next, you are ready to authenticate users! You will need two routes: one for redirecting the user to the OAuth provider, and another for receiving the callback from the provider after authentication. We will access Socialite using the `Socialite` facade:
+
+이제 사용자를 인증할 준비가 되었습니다! 이제 두개의 라우트가 필요합니다: 하나는 사용자를 OAuth 서비로 리다이렉팅 하는 라우팅이고, 다른 하나는 인증후 받는 콜백입니다. `Socialite` 파사드를 사용하여 Socialite에 엑세스할 수 있습니다:
 
     <?php
 
@@ -74,15 +99,22 @@ Next, you are ready to authenticate users! You will need two routes: one for red
 
 The `redirect` method takes care of sending the user to the OAuth provider, while the `user` method will read the incoming request and retrieve the user's information from the provider.
 
+`redirect` 메소드는 사용자를 OAuth 서비스로 이동시키고, `user` 메소드는 유입되는 request를 읽어들여, 사용자 정보를 조회합니다.
+
 Of course, you will need to define routes to your controller methods:
+
+물론, 다음처럼 컨트롤러 메소드를 위한 라우를 정의해야 합니다:
 
     Route::get('login/github', 'Auth\LoginController@redirectToProvider');
     Route::get('login/github/callback', 'Auth\LoginController@handleProviderCallback');
 
 <a name="optional-parameters"></a>
 ## Optional Parameters
+## 옵션 파라미터
 
 A number of OAuth providers support optional parameters in the redirect request. To include any optional parameters in the request, call the `with` method with an associative array:
+
+몇몇 OAuth 프로바이더는 리다이렉트 요청에서 옵션 파라미터를 지원합니다. request에 옵션 파라미터를 포함하도록 하려면, 연관된 값을 배열로 `with` 메소드와 함께 호출하면 됩니다:
 
     return Socialite::driver('google')
         ->with(['hd' => 'example.com'])
@@ -90,10 +122,15 @@ A number of OAuth providers support optional parameters in the redirect request.
 
 > {note} When using the `with` method, be careful not to pass any reserved keywords such as `state` or `response_type`.
 
+> {note} `with` 메소드를 사용할 때, `state` 와 `response_type` 같은 예약된 키워드를 사용하지 않도록 주의하십시오.
+
 <a name="access-scopes"></a>
 ## Access Scopes
+## 엑세스 스코프
 
 Before redirecting the user, you may also add additional "scopes" on the request using the `scopes` method. This method will merge all existing scopes with the ones you supply:
+
+사용자를 리다이렉팅하기 전에, `scopes` 메소드를 사용하여 request 에 "스코프"를 추가할 수 있습니다. 이 메소드는 기존에 존재하는 모든 스코프를 사용자가 제공하는 스코프와 머지(merge)합니다:
 
     return Socialite::driver('github')
         ->scopes(['read:user', 'public_repo'])
@@ -101,21 +138,29 @@ Before redirecting the user, you may also add additional "scopes" on the request
 
 You can overwrite all exisiting scopes using the `setScopes` method:
 
+`setScopes` 메소드를 사용하면 기존에 존재하는 모든 스코프를 덮어 쓸 수 있습니다:
+
     return Socialite::driver('github')
         ->setScopes(['read:user', 'public_repo'])
         ->redirect();
 
 <a name="stateless-authentication"></a>
 ## Stateless Authentication
+## 상태를 유지하지 않는 인증
 
 The `stateless` method may be used to disable session state verification. This is useful when adding social authentication to an API:
+
+`stateless` 메소드는 세션의 상태를 확인하지 않게 하도록 하기 위해 사용될 수 있습니다. 이는 소셜 로그인을 API에 추가할 때 유용합니다:
 
     return Socialite::driver('google')->stateless()->user();
 
 <a name="retrieving-user-details"></a>
 ## Retrieving User Details
+## 사용자의 상세정보 조회하기
 
 Once you have a user instance, you can grab a few more details about the user:
+
+사용자 인스턴스를 획득하고 나면, 여기에서 몇가지 상세 정보를 획득할 수 있습니다:
 
     $user = Socialite::driver('github')->user();
 
@@ -136,13 +181,19 @@ Once you have a user instance, you can grab a few more details about the user:
     $user->getAvatar();
 
 #### Retrieving User Details From A Token (OAuth2)
+#### 토큰으로 부터 사용자 상세정보 조회하기 (OAuth2)
 
 If you already have a valid access token for a user, you can retrieve their details using the `userFromToken` method:
 
+사용자에 대한 유요한 엑세스 토큰을 가지고 있는 경우 `userFromToken` 메소드를 사용하여 상세 정보를 조회할 수 있습니다:
+
     $user = Socialite::driver('github')->userFromToken($token);
-    
+
 #### Retrieving User Details From A Token And Secret (OAuth1)
+#### 토큰과 비밀번호를 사용하여 사용자 정보 조회하기 (OAuth1)
 
 If you already have a valid pair of token / secret for a user, you can retrieve their details using the `userFromTokenAndSecret` method:
+
+사용자의 유효한 토큰과 비밀번호를 가지고 있다면, `userFromTokenAndSecret` 메소드를 사용하여 사용자 정보를 조회할 수 있습니다:
 
     $user = Socialite::driver('twitter')->userFromTokenAndSecret($token, $secret);


### PR DESCRIPTION
변경사항 없습니다.

다만 [https://laravel.kr/docs/5.5/passport](https://laravel.kr/docs/5.5/passport) 문서본에 앞단에 번역문이 나오지 않고 있습니다.

The Passport service provider registers its own database migration directory with the framework, so you should migrate your database after registering the provider. The Passport migrations will create the tables your application needs to store clients and access tokens:

Passport 서비스 프로바이더는 고유한 데이터베이스 마이그레이션 디렉토리를 등록하기 때문에, 서비스 프로바이더를 등록한 뒤에 데이터베이스 마이그레이션을 실행해야 합니다. Passport 마이그레이션을 실행하면 어플리케이션에서 필요한 클라이언트와 엑세스 토큰을 저장하는 테이블이 생성됩니다:
