### PR TITLE
5.6 eloquent 

### DIFF
--- a/kr/eloquent-collections.md
+++ b/kr/eloquent-collections.md
@@ -1,15 +1,24 @@
 # Eloquent: Collections
+# Eloquent: Collections
 
 - [Introduction](#introduction)
+- [소개](#introduction)
 - [Available Methods](#available-methods)
+- [사용 가능한 메소드들](#available-methods)
 - [Custom Collections](#custom-collections)
+- [사용자 지정 Collections](#custom-collections)
 
 <a name="introduction"></a>
 ## Introduction
+## 소개
 
 All multi-result sets returned by Eloquent are instances of the `Illuminate\Database\Eloquent\Collection` object, including results retrieved via the `get` method or accessed via a relationship. The Eloquent collection object extends the Laravel [base collection](/docs/{{version}}/collections), so it naturally inherits dozens of methods used to fluently work with the underlying array of Eloquent models.
 
+`get` 메소드를 통하거나 하나의 `relationship-관계`를 통해서 Eloquent로 부터 반환되는 모든 멀티 레코드 결과는 `Illuminate\Database\Eloquent\Collection` 객체의 인스턴스가 됩니다. Eloquent 컬렉션 객체는 라라벨의 [base collection](/docs/{{version}}/collections)을 상속받기 때문에, 자연스럽게 ELoquent 모델에 대한 결과에서 다양하고 편리한 메소드들을 사용할 수 있습니다. 
+
 Of course, all collections also serve as iterators, allowing you to loop over them as if they were simple PHP arrays:
+
+또한 당연하게도, 모든 컬렉션은 Iterators(반복자)이기 때문에, 간단한 PHP 배열과 같이 반복문 안에서 사용할 수도 있습니다: 
 
     $users = App\User::where('active', 1)->get();
 
@@ -19,7 +28,9 @@ Of course, all collections also serve as iterators, allowing you to loop over th
 
 However, collections are much more powerful than arrays and expose a variety of map / reduce operations that may be chained using an intuitive interface. For example, let's remove all inactive models and gather the first name for each remaining user:
 
-    $users = App\User::all();
+하지만, 컬렉션은 배열보다 강력하며, 직관적인 인터페이스를 사용하여 메소드 체인이 가능한 map / reduce 메소드를 사용 할 수 있습니다. 예를들어 비활성화된 모델을 제거하고 남은 사용자의 이름을 확인하려면 다음과 같이 하면 됩니다:
+
+    $users = App\User::where('active', 1)->get();
 
     $names = $users->reject(function ($user) {
         return $user->active === false;
@@ -30,12 +41,18 @@ However, collections are much more powerful than arrays and expose a variety of 
 
 > {note} While most Eloquent collection methods return a new instance of an Eloquent collection, the `pluck`, `keys`, `zip`, `collapse`, `flatten` and `flip` methods return a [base collection](/docs/{{version}}/collections) instance. Likewise, if a `map` operation returns a collection that does not contain any Eloquent models, it will be automatically cast to a base collection.
 
+> {note} 대부분의 Eloquent 컬렉션 메소드는 새로운 Eloquent 컬렉션 인스턴스를 반환하고, `pluck`, `keys`, `zip`, `collapse`, `flatten` 그리고 `flip` 메소드는 [기본 컬렉션](/docs/{{version}}/collections) 인스턴스를 반환합니다. 또한 만약 `map` 실행이 Eloquent 모델을 포함하지 않는 컬렉션을 반환한다면, 자동으로 기본 컬렉션으로 캐스팅 될 것입니다.
+
 <a name="available-methods"></a>
 ## Available Methods
+## 사용가능한 메소드들 
 
 ### The Base Collection
+### 기본 컬렉션
 
 All Eloquent collections extend the base [Laravel collection](/docs/{{version}}/collections) object; therefore, they inherit all of the powerful methods provided by the base collection class:
+
+모든 Eloquent 컬렉션은 [Laravel collection](/docs/{{version}}/collections) 객체를 상속받습니다; 따라서 라라벨의 기본 컬렉션 클래스의 모든 강력한 메소드들을 상속받습니다. 
 
 <style>
     #collection-method-list > p {
@@ -47,8 +64,6 @@ All Eloquent collections extend the base [Laravel collection](/docs/{{version}}/
         display: block;
     }
 </style>
-
-<div id="collection-method-list" markdown="1">
 
 [all](/docs/{{version}}/collections#method-all)
 [average](/docs/{{version}}/collections#method-average)
@@ -140,12 +155,13 @@ All Eloquent collections extend the base [Laravel collection](/docs/{{version}}/
 [whereNotInStrict](/docs/{{version}}/collections#method-wherenotinstrict)
 [zip](/docs/{{version}}/collections#method-zip)
 
-</div>
-
 <a name="custom-collections"></a>
 ## Custom Collections
+## 사용자 정의 컬렉션
 
 If you need to use a custom `Collection` object with your own extension methods, you may override the `newCollection` method on your model:
+
+만약 여러분이 고유한 `Collection` 객체를 사용하고자 한다면, 모델 클래스에서 `newCollection` 메소드를 오버라이드(재지정) 하면 됩니다:
 
     <?php
 
@@ -169,3 +185,5 @@ If you need to use a custom `Collection` object with your own extension methods,
     }
 
 Once you have defined a `newCollection` method, you will receive an instance of your custom collection anytime Eloquent returns a `Collection` instance of that model. If you would like to use a custom collection for every model in your application, you should override the `newCollection` method on a base model class that is extended by all of your models.
+
+`newCollection` 메소드를 정의하고 나면, Eloquent가 모델에서 `Collection` 인스턴스를 반환할 때 언제나 여러분이 지정한 사용자 정의 컬렉션을 반환할 것입니다. 어플리케이션의 모든 모델에서 사용자 정의 컬렉션을 사용하기를 원한다면, 모든 모델 클래스들이 상속받는 기본 Model 클래스에서 `newCollection` 메소드를 오버라이드 해야만합니다. 

--- a/kr/eloquent-mutators.md
+++ b/kr/eloquent-mutators.md
@@ -1,27 +1,44 @@
 # Eloquent: Mutators
+# Eloquent: Mutators
 
 - [Introduction](#introduction)
+- [소개](#introduction)
+- [Accessors & Mutators](#accessors-and-mutators)
 - [Accessors & Mutators](#accessors-and-mutators)
     - [Defining An Accessor](#defining-an-accessor)
+    - [Accessor 정의하기](#defining-an-accessor)
     - [Defining A Mutator](#defining-a-mutator)
+    - [Mutator 정의하기](#defining-a-mutator)
 - [Date Mutators](#date-mutators)
+- [날짜 Mutators](#date-mutators)
 - [Attribute Casting](#attribute-casting)
+- [속성(Attribute) 캐스팅](#attribute-casting)
     - [Array & JSON Casting](#array-and-json-casting)
+    - [배열 & JSON 캐스팅](#array-and-json-casting)
 
 <a name="introduction"></a>
 ## Introduction
+## 소개하기
 
 Accessors and mutators allow you to format Eloquent attribute values when you retrieve or set them on model instances. For example, you may want to use the [Laravel encrypter](/docs/{{version}}/encryption) to encrypt a value while it is stored in the database, and then automatically decrypt the attribute when you access it on an Eloquent model.
 
+Accessors 와 mutators 는 Eloquent 모델에서 속성값을 찾을 때나 값을 설정할 때 포맷을 가능하게 합니다. 예를 들어 데이터베이스에서 값을 저장할 때, [라라벨 encrypter](/docs/{{version}}/encryption)을 사용하여 값을 암호화 하고, Eloquent 모델에서 값에 엑세스 할 때 자동으로 복호화 하기를 원할 수도 있습니다. 
+
 In addition to custom accessors and mutators, Eloquent can also automatically cast date fields to [Carbon](https://github.com/briannesbitt/Carbon) instances or even [cast text fields to JSON](#attribute-casting).
 
+사용자가 지정한 accessors 와 mutators 에 더하여, Eloquent 는 또한 자동으로 날짜 필드를 [Carbon](https://github.com/briannesbitt/Carbon) 인스턴스로 캐스팅 하거나, [텍스트 필드를 JSON으로 캐스팅](#attribute-casting) 할 수 있습니다. 
+
 <a name="accessors-and-mutators"></a>
+## Accessors & Mutators
 ## Accessors & Mutators
 
 <a name="defining-an-accessor"></a>
 ### Defining An Accessor
+### Accessor 정의하기
 
 To define an accessor, create a `getFooAttribute` method on your model where `Foo` is the "studly" cased name of the column you wish to access. In this example, we'll define an accessor for the `first_name` attribute. The accessor will automatically be called by Eloquent when attempting to retrieve the value of the `first_name` attribute:
+
+accessor를 정의하기 위해서, `Foo` 모델에 접근하고자 하는 컬럼을 위한 `getFooAttribute` 메소드를 "studly" 케이스 형태의 이름으로 생성합니다. 다음 예제에서는 `first_name` 컬럽에 대한 accessor를 정의할 것입니다. accessor는 `first_name` 값이 찾아졌을 때 Eloquent 에 의해서 자동으로 호출될 것입니다. 
 
     <?php
 
@@ -45,11 +62,15 @@ To define an accessor, create a `getFooAttribute` method on your model where `Fo
 
 As you can see, the original value of the column is passed to the accessor, allowing you to manipulate and return the value. To access the value of the accessor, you may access the `first_name` attribute on a model instance:
 
+위에서 볼 수 있듯이, 컬럼의 원래 값이 accessor 로 전달되고, 값을 가공하여 반환됩니다. accessor의 값에 액세스하려면, 모델 인스턴스의 `first_name` 속성에 액세스하면 됩니다.
+
     $user = App\User::find(1);
 
     $firstName = $user->first_name;
 
 Of course, you may also use accessors to return new, computed values from existing attributes:
+
+물론 이미 존재하는 속성값의 새롭게 변경하는데에도 accessor 를 사용할 수 있습니다:
 
     /**
      * Get the user's full name.
@@ -63,8 +84,11 @@ Of course, you may also use accessors to return new, computed values from existi
 
 <a name="defining-a-mutator"></a>
 ### Defining A Mutator
+### Mutator 정의하기
 
 To define a mutator, define a `setFooAttribute` method on your model where `Foo` is the "studly" cased name of the column you wish to access. So, again, let's define a mutator for the `first_name` attribute. This mutator will be automatically called when we attempt to set the value of the `first_name` attribute on the model:
+
+mutator 를 정의하기 위해서, `Foo` 모델 클래스에 엑세스 하고자 하는 컬럼을 위한 `setFooAttribute` 메소드를 "카멜" 케이스 형태의 이름으로 정의합니다. 이번에도 `first_name` 속성에 대해서 mutator를 정의하겠습니다. 이 mutator는 모델에서 `first_name` 속성을 변경하려고 할 때, 자동으로 호출 될 것입니다. 
 
     <?php
 
@@ -88,16 +112,23 @@ To define a mutator, define a `setFooAttribute` method on your model where `Foo`
 
 The mutator will receive the value that is being set on the attribute, allowing you to manipulate the value and set the manipulated value on the Eloquent model's internal `$attributes` property. So, for example, if we attempt to set the `first_name` attribute to `Sally`:
 
+mutator 는 속성에 설정하고자 하는 값을 전달 받아, 값을 변형하고, 변형된 값을 Eloquent 모델의 `$attributes` 속성에 지정할 것입니다. 다음 처럼`first_name` 속성을 `Sally` 로 지정해 보겠습니다. 
+
     $user = App\User::find(1);
 
     $user->first_name = 'Sally';
 
 In this example, the `setFirstNameAttribute` function will be called with the value `Sally`. The mutator will then apply the `strtolower` function to the name and set its resulting value in the internal `$attributes` array.
 
+이 예제에서 `setFirstNameAttribute` 함수는 `Sally` 라는 값과 함께 호출 될것입니다. mutator 는 이름에 대해 `strtolower` 함수가 실행되도록 하여 그 결과 값을 내부 `$attributes` 배열에 지정할 것입니다. 
+
 <a name="date-mutators"></a>
 ## Date Mutators
+## 날짜 Mutators
 
 By default, Eloquent will convert the `created_at` and `updated_at` columns to instances of [Carbon](https://github.com/briannesbitt/Carbon), which extends the PHP `DateTime` class to provide an assortment of helpful methods. You may customize which dates are automatically mutated, and even completely disable this mutation, by overriding the `$dates` property of your model:
+
+기본적으로 Eloquent는 `created_at` 컬럼과 `updated_at` 컬럼을 유용한 메소드 모음을 가지고 있으며,  PHP `DateTime` 클래스의 확장인 [Carbon](https://github.com/briannesbitt/Carbon) 클래스의 인스턴스로 변환해줍니다. 사용자 정의 모델의 `$dates` 메소드를 재정의 하여 날짜가 자동으로 바뀌도록 활성화 또는 비활성화 할 수 있습니다.
 
     <?php
 
@@ -121,6 +152,8 @@ By default, Eloquent will convert the `created_at` and `updated_at` columns to i
 
 When a column is considered a date, you may set its value to a UNIX timestamp, date string (`Y-m-d`), date-time string, and of course a `DateTime` / `Carbon` instance, and the date's value will automatically be correctly stored in your database:
 
+컬럼이 날짜라고 추정되는 경우, 여러분은 이 값을 UNIX 타임스탬프 값, date(`Y-m-d`) 문자열 값, 날짜-시간에 대한 문자열 값, 그리고 `DateTime` / `Carbon` 클래스의 인스턴스 값으로 설정할 수 있고, 날짜는 자동으로 데이터베이스에 정확하게 저장될 것입니다:
+
     $user = App\User::find(1);
 
     $user->deleted_at = now();
@@ -129,13 +162,18 @@ When a column is considered a date, you may set its value to a UNIX timestamp, d
 
 As noted above, when retrieving attributes that are listed in your `$dates` property, they will automatically be cast to [Carbon](https://github.com/briannesbitt/Carbon) instances, allowing you to use any of Carbon's methods on your attributes:
 
+위에서 보다시피, `$dates` 속성에 나열된 값을 가져오려고 하는 경우, 이 값은 자동으로 [Carbon](https://github.com/briannesbitt/Carbon)인스턴스로 캐스팅 될것이기 때문에, 속성에 대해서 Carbon의 메소드를 아무거나 사용할 수 있습니다:
+
     $user = App\User::find(1);
 
     return $user->deleted_at->getTimestamp();
 
 #### Date Formats
+#### Date Formats
 
 By default, timestamps are formatted as `'Y-m-d H:i:s'`. If you need to customize the timestamp format, set the `$dateFormat` property on your model. This property determines how date attributes are stored in the database, as well as their format when the model is serialized to an array or JSON:
+
+기본적으로, 타임스탬프 형식은 `'Y-m-d H:i:s'` 입니다. 타임 스탬프 형식을 별도로 지정할 필요가 있다면, 모델에서 `$dateFormat` 속성을 설정하면 됩니다. 이 속성은 데이터베이스에서 날짜 속성이 어떻게 저장되어야 하는지, 그리고 모델이 배열 또는 JSON 형태로 serialize 될 때의 형식을 결정합니다: 
 
     <?php
 
@@ -155,10 +193,15 @@ By default, timestamps are formatted as `'Y-m-d H:i:s'`. If you need to customiz
 
 <a name="attribute-casting"></a>
 ## Attribute Casting
+## 속성(Attribute) 캐스팅
 
 The `$casts` property on your model provides a convenient method of converting attributes to common data types. The `$casts` property should be an array where the key is the name of the attribute being cast and the value is the type you wish to cast the column to. The supported cast types are: `integer`, `real`, `float`, `double`, `string`, `boolean`, `object`, `array`, `collection`, `date`, `datetime`, and `timestamp`.
 
+모델의 `$casts` 값은 속성에 대해서 공통의 데이타 타입으로 변환하는 편리함 메소드를 제공합니다. `$casts` 값은 캐스팅 하고자 하는 속성들의 이름들을 key로 가지고, 그 타입을 값으로 가지는 배열 형태여야 합니다. 지원하는 캐스트 타입 유형은 `integer`, `real`, `float`, `double`, `string`, `boolean`, `object`, `array`, `collection`, `date`, `datetime`, `timestamp`입니다.
+
 For example, let's cast the `is_admin` attribute, which is stored in our database as an integer (`0` or `1`) to a boolean value:
+
+예를 들어, 데이터베이스에 정수형으로 저장된 `is_admin` 속성을 boolean 값으로 캐스팅 해 봅시다: 
 
     <?php
 
@@ -180,6 +223,8 @@ For example, let's cast the `is_admin` attribute, which is stored in our databas
 
 Now the `is_admin` attribute will always be cast to a boolean when you access it, even if the underlying value is stored in the database as an integer:
 
+이제 사용자가 액세스 할 때 데이터베이스에 정수형 값으로 저장되어있는 경우에도 `is_admin` 속성은 항상 boolean으로 캐스팅됩니다: 
+
     $user = App\User::find(1);
 
     if ($user->is_admin) {
@@ -188,8 +233,11 @@ Now the `is_admin` attribute will always be cast to a boolean when you access it
 
 <a name="array-and-json-casting"></a>
 ### Array & JSON Casting
+### 배열 && JSON 캐스팅
 
 The `array` cast type is particularly useful when working with columns that are stored as serialized JSON. For example, if your database has a `JSON` or `TEXT` field type that contains serialized JSON, adding the `array` cast to that attribute will automatically deserialize the attribute to a PHP array when you access it on your Eloquent model:
+
+`array` 타입 캐스팅은 직렬화 된 JSON으로 컬럼에 저장하는 작업을 할 때 특히 유용합니다. 예를 들어, 데이터베이스에 직렬화 된 JSON을 포함하는 `JSON` 또는 `TEXT` 필드가있는 경우, `array` 캐스팅을 해당 속성에 추가하면 Eloquent 사용자 정의 모델에 접근할 때 자동으로 역 직렬화 된 PHP 배열 값이 해당 속성 값으로 들어갑니다:
 
     <?php
 
@@ -210,6 +258,8 @@ The `array` cast type is particularly useful when working with columns that are 
     }
 
 Once the cast is defined, you may access the `options` attribute and it will automatically be deserialized from JSON into a PHP array. When you set the value of the `options` attribute, the given array will automatically be serialized back into JSON for storage:
+
+캐스팅이 정의하고 나서, `options` 속성에 액세스하면 자동으로 JSON 이 PHP 배열로 deserialize 될 것입니다. `options` 속성에 값을 설정하면, 주어진 배열은 자동으로 JSON으로 serialize 될 것입니다:
 
     $user = App\User::find(1);
 

--- a/kr/eloquent-relationships.md
+++ b/kr/eloquent-relationships.md
@@ -1,54 +1,95 @@
 # Eloquent: Relationships
+# Eloquent: Relationships - 관계
 
 - [Introduction](#introduction)
+- [소개](#introduction)
 - [Defining Relationships](#defining-relationships)
+- [관계 정의하기](#defining-relationships)
     - [One To One](#one-to-one)
+    - [1:1(일대일) 관계](#one-to-one)
     - [One To Many](#one-to-many)
+    - [1:*(일대다) 관계](#one-to-many)
     - [One To Many (Inverse)](#one-to-many-inverse)
+    - [1:*(일대다) 역관계](#one-to-many)
     - [Many To Many](#many-to-many)
+    - [\*:*(다대다) 관계](#many-to-many)
     - [Has Many Through](#has-many-through)
+    - [연결을 통한 다수를 가지는 관계](#has-many-through)
     - [Polymorphic Relations](#polymorphic-relations)
+    - [다형성 관계](#polymorphic-relations)
     - [Many To Many Polymorphic Relations](#many-to-many-polymorphic-relations)
+    - [다대다 다형성 관계](#many-to-many-polymorphic-relations)
 - [Querying Relations](#querying-relations)
+- [관계 쿼리 질의하기](#querying-relations)
     - [Relationship Methods Vs. Dynamic Properties](#relationship-methods-vs-dynamic-properties)
+    - [관계 메소드 Vs. 동적 속성](#relationship-methods-vs-dynamic-properties)
     - [Querying Relationship Existence](#querying-relationship-existence)
+    - [존재하는 관계에 대한 쿼리 질의하기](#querying-relationship-existence)
     - [Querying Relationship Absence](#querying-relationship-absence)
+    - [관계된 모델이 존재하지 않는 것을 확인하며 질의하기](#querying-relationship-absence)
     - [Counting Related Models](#counting-related-models)
+    - [연관된 모델 수량 확인하기-카운트](#counting-related-models)
 - [Eager Loading](#eager-loading)
+- [Eager 로딩](#eager-loading)
     - [Constraining Eager Loads](#constraining-eager-loads)
+    - [Eager 로딩 조건 제한하기](#constraining-eager-loads)
     - [Lazy Eager Loading](#lazy-eager-loading)
+    - [지연 Eager 로딩](#lazy-eager-loading)
 - [Inserting & Updating Related Models](#inserting-and-updating-related-models)
+- [연관된 모델 삽입하기](#inserting-and-updating-related-models)
     - [The `save` Method](#the-save-method)
+    - [`save` 메소드](#the-save-method)
     - [The `create` Method](#the-create-method)
+    - [`create` 메소드](#the-create-method)
     - [Belongs To Relationships](#updating-belongs-to-relationships)
+    - [소속된 관계](#updating-belongs-to-relationships)
     - [Many To Many Relationships](#updating-many-to-many-relationships)
+    - [다대다 관계](#updating-many-to-many-relationships)
 - [Touching Parent Timestamps](#touching-parent-timestamps)
+- [부모의 타임스탬프 값 갱신하기](#touching-parent-timestamps)
 
 <a name="introduction"></a>
 ## Introduction
+## 소개하기
 
 Database tables are often related to one another. For example, a blog post may have many comments, or an order could be related to the user who placed it. Eloquent makes managing and working with these relationships easy, and supports several different types of relationships:
 
+데이터베이스 테이블은 주로 서로 관련되어 있습니다. 예를 들어, 한 블로그 포스트가 많은 댓글을 가지고 있거나 어떤 명령이 그 명령을 내린 사용자와 관련되어 있을 수 있습니다. Eloquent는 이 relationship들과 관련한 작업을 하거나 관리하는 것을 쉽게 해주며 여러 타입의 relationship을 지원합니다:
+
 - [One To One](#one-to-one)
+- [1:1(일대일) 관계](#one-to-one)
 - [One To Many](#one-to-many)
+- [1:*(일대다) 관계](#one-to-many)
 - [Many To Many](#many-to-many)
+- [*:*(대다다) 관계](#many-to-many)
 - [Has Many Through](#has-many-through)
+- [연결을 통한 다수를 가지는 관계](#has-many-through)
 - [Polymorphic Relations](#polymorphic-relations)
+- [다형성 관계](#polymorphic-relations)
 - [Many To Many Polymorphic Relations](#many-to-many-polymorphic-relations)
+- [다대다 다형성 관계](#many-to-many-polymorphic-relations)
 
 <a name="defining-relationships"></a>
 ## Defining Relationships
+## 관계 정의하기
 
 Eloquent relationships are defined as methods on your Eloquent model classes. Since, like Eloquent models themselves, relationships also serve as powerful [query builders](/docs/{{version}}/queries), defining relationships as methods provides powerful method chaining and querying capabilities. For example, we may chain additional constraints on this `posts` relationship:
+
+Eloquent relationship들은 Eloquent 모델 클래스에 메소드로 정의되어 있습니다. Eloquent 모델들과 같이 relationships-관계를 정의한 것은 강력한 [쿼리 빌더](/docs/{{version}}/queries)로써의 기능으로도 작동하기 때문에 relationships-관계를 메소드로 정의하는 것은 강력한 메소드 체이닝과 쿼리 능력을 제공하게됩니다. 예를 들어 다음의 `post` 관계에 대해서 추가적인 제약조건을 체이닝할 수도 있습니다.:
 
     $user->posts()->where('active', 1)->get();
 
 But, before diving too deep into using relationships, let's learn how to define each type.
 
+relationship을 사용하는 법에 더 깊이 알아보기 전에, 각 타입을 어떻게 정의햐는지 알아보도록 합시다.
+
 <a name="one-to-one"></a>
 ### One To One
+### 1:1(일대일) 관계 정의하기
 
 A one-to-one relationship is a very basic relation. For example, a `User` model might be associated with one `Phone`. To define this relationship, we place a `phone` method on the `User` model. The `phone` method should call the `hasOne` method and return its result:
+
+일대일 relationship은 아주 기본적인 관계입니다. 예를 들어, 하나의 `User` 모델이 하나의 `Phone`과 관계되어 있을 수 있습니다. 이 relationship을 정의하기 위해 `User` 모델에 `phone` 메소드를 구성합니다. `phone` 메소드는 `hasOne` 메소드를 호출하게 되고 그 결과를 반환할 것입니다:
 
     <?php
 
@@ -69,19 +110,28 @@ A one-to-one relationship is a very basic relation. For example, a `User` model 
 
 The first argument passed to the `hasOne` method is the name of the related model. Once the relationship is defined, we may retrieve the related record using Eloquent's dynamic properties. Dynamic properties allow you to access relationship methods as if they were properties defined on the model:
 
+`hasOne` 메소드에 전달되는 첫번째 인자는 관련된 모델의 이름입니다. Relationship이 정의되었다면 Eloquent의 동적 속성을 이용하여 관련된 기록을 찾을 수 있습니다. 동적 속성은 모델에 정의된 속성에 접근하는 방식과 같은 방식으로 relationship 메소드에 접근하는 것을 허용합니다:
+
     $phone = User::find(1)->phone;
 
 Eloquent determines the foreign key of the relationship based on the model name. In this case, the `Phone` model is automatically assumed to have a `user_id` foreign key. If you wish to override this convention, you may pass a second argument to the `hasOne` method:
+
+Eloquent는 모델 명에 근거하여 relationship의 외래 키(foreign key)를 결정합니다. 이 경우, `Phone` 모델은 `user_id` 외래 키를 가질 것이라고 자동으로 추정합니다. 이 추정사항을 재정의하고 싶다면 `hasOne` 메소드로 두번째 인자를 전달하면 됩니다:
 
     return $this->hasOne('App\Phone', 'foreign_key');
 
 Additionally, Eloquent assumes that the foreign key should have a value matching the `id` (or the custom `$primaryKey`) column of the parent. In other words, Eloquent will look for the value of the user's `id` column in the `user_id` column of the `Phone` record. If you would like the relationship to use a value other than `id`, you may pass a third argument to the `hasOne` method specifying your custom key:
 
+Eloquent는 또한 외래 키가 부모의 `id` 컬럼(또는 사용자가 정의한 `$primaryKey`)에 상응하는 값을 가지고 있다고 추정합니다. 즉, Eloquent는 `Phone`레코드의 `user_id` 컬럼에서 사용자 `id` 컬럼의 값을 찾을 것입니다. Relationship이 `id`가 아닌 다른 값을 사용하고자 한다면 커스텀 키를 지정하는 세번째 인자를 `hasOne` 메소드로 전달하면 됩니다:
+
     return $this->hasOne('App\Phone', 'foreign_key', 'local_key');
 
 #### Defining The Inverse Of The Relationship
+#### 관계의 역(반대) 정의하기
 
 So, we can access the `Phone` model from our `User`. Now, let's define a relationship on the `Phone` model that will let us access the `User` that owns the phone. We can define the inverse of a `hasOne` relationship using the `belongsTo` method:
+
+이제 `User`에서 `Phone` 모델에 접근할 수 있습니다. 반대로, `Phone` 모델에 relationship을 정의하여 phone을 소유하는 `User`에 접근할 수 있도록 해봅시다. `belongsTo` 메소드를 이용하면 `hasOne` relationship의 반대를 정의할 수 있습니다:
 
     <?php
 
@@ -102,6 +152,8 @@ So, we can access the `Phone` model from our `User`. Now, let's define a relatio
 
 In the example above, Eloquent will try to match the `user_id` from the `Phone` model to an `id` on the `User` model. Eloquent determines the default foreign key name by examining the name of the relationship method and suffixing the method name with `_id`. However, if the foreign key on the `Phone` model is not `user_id`, you may pass a custom key name as the second argument to the `belongsTo` method:
 
+위 예에서 Eloquent는 `Phone` 모델의 `user_id`와 `User` 모델의 `id`를 비교해볼 것입니다. Eloquent는 relationship 메소드의 이름을 검사하고 메소드 이름에 `_id`를 붙여서 외래 키의 기본 이름으로 결정합니다. 하지만 `Phone` 모델의 외래 키가 `user_id`가 아니라면 커스텀 키 이름을 두번째 인자로 `belongsTo`에 전달하면 됩니다:
+
     /**
      * Get the user that owns the phone.
      */
@@ -111,6 +163,8 @@ In the example above, Eloquent will try to match the `user_id` from the `Phone` 
     }
 
 If your parent model does not use `id` as its primary key, or you wish to join the child model to a different column, you may pass a third argument to the `belongsTo` method specifying your parent table's custom key:
+
+부모 모델이 `id`를 프라이머리 키로 사용하지 않거나 자식 모델을 다른 컬럼에 조인시키고 싶다면 부모 테이블의 커스텀 키를 지정하는 세번째 인자를 `belongsTo` 메소드로 전달하면 됩니다:
 
     /**
      * Get the user that owns the phone.
@@ -122,8 +176,11 @@ If your parent model does not use `id` as its primary key, or you wish to join t
 
 <a name="default-models"></a>
 #### Default Models
+#### 기본 모델
 
 The `belongsTo` relationship allows you to define a default model that will be returned if the given relationship is `null`. This pattern is often referred to as the [Null Object pattern](https://en.wikipedia.org/wiki/Null_Object_pattern) and can help remove conditional checks in your code. In the following example, the `user` relation will return an empty `App\User` model if no `user` is attached to the post:
+
+`belongsTo` 관계에서 주어진 관계가 만약 `null` 인 경우에 반환할 기본모델을 정의할 수 있습니다. 이 패턴은 [Null 오브젝트 패턴](https://en.wikipedia.org/wiki/Null_Object_pattern) 이라고 하며 코드에서 조건식을 제거하는데 도움이 됩니다. 다음의 예제에서 `user` 관계는 포스트에 추가된 `user` 가 없는 경우 비어 있는 `App/User` 모델을 반환합니다:
 
     /**
      * Get the author of the post.
@@ -134,6 +191,8 @@ The `belongsTo` relationship allows you to define a default model that will be r
     }
 
 To populate the default model with attributes, you may pass an array or Closure to the `withDefault` method:
+
+기본 모델에 속성을 구성하려면, `withDefault` 메소드에 배열 또는 클로저를 전달하면 됩니다:
 
     /**
      * Get the author of the post.
@@ -157,8 +216,11 @@ To populate the default model with attributes, you may pass an array or Closure 
 
 <a name="one-to-many"></a>
 ### One To Many
+### 1:*(일대다) 관계 정의하기
 
 A "one-to-many" relationship is used to define relationships where a single model owns any amount of other models. For example, a blog post may have an infinite number of comments. Like all other Eloquent relationships, one-to-many relationships are defined by placing a function on your Eloquent model:
+
+"일대다" relationship은 하나의 모델이 다른 모델의 어떤 부분이라도 소유할 경우의 relationship을 정의하는데 사용됩니다. 예를 들어, 한 블로그 게시물이 댓글을 무제한으로 가질 수 있습니다. 다른 모든 Eloquent relationship들과 같이, 일대다 relationship들은 Eloquent 모델에 함수를 통해서 정의됩니다:
 
     <?php
 
@@ -179,7 +241,11 @@ A "one-to-many" relationship is used to define relationships where a single mode
 
 Remember, Eloquent will automatically determine the proper foreign key column on the `Comment` model. By convention, Eloquent will take the "snake case" name of the owning model and suffix it with `_id`. So, for this example, Eloquent will assume the foreign key on the `Comment` model is `post_id`.
 
+앞서 언급했듯이 Eloquent는 `Comment` 모델에 적절한 외래 키를 자동으로 결정합니다. Eloquent는 관례적으로 소유하는 모델의 "snake case" 이름에 `_id`를 붙일 것입니다. 따라서 이 예에서 Eloqent는 `Comment` 모델의 외래 키가 `post_id`일 것이라고 추정합니다.
+
 Once the relationship has been defined, we can access the collection of comments by accessing the `comments` property. Remember, since Eloquent provides "dynamic properties", we can access relationship methods as if they were defined as properties on the model:
+
+관계가 정의되었다면 `comments` 속성에 접근하여 댓글 모음에 엑세스할 수 있습니다. 앞서 말했듯이 Eloquent는 "동적 속성"을 제공하기 때문에 모델의 속성에 접근하듯이 relationship-관계 메소드에 접근할 수 있습니다:
 
     $comments = App\Post::find(1)->comments;
 
@@ -189,9 +255,13 @@ Once the relationship has been defined, we can access the collection of comments
 
 Of course, since all relationships also serve as query builders, you can add further constraints to which comments are retrieved by calling the `comments` method and continuing to chain conditions onto the query:
 
+물론 모든 관계들은 쿼리 빌더로도 역할하기 때문에 `comments` 메소드를 호출하고 쿼리에 조건들을 계속해서 체인하는 것을 통해 어떤 댓글들이 조회되는지에 대한 제한들을 추가할 수 있습니다:
+
     $comments = App\Post::find(1)->comments()->where('title', 'foo')->first();
 
 Like the `hasOne` method, you may also override the foreign and local keys by passing additional arguments to the `hasMany` method:
+
+`hasOne` 메소드와 같이 `hasMany` 메소드에 추가적인 인자들을 전달하여 외래 및 로컬 키들을 재지정 할 수 있습니다:
 
     return $this->hasMany('App\Comment', 'foreign_key');
 
@@ -199,8 +269,11 @@ Like the `hasOne` method, you may also override the foreign and local keys by pa
 
 <a name="one-to-many-inverse"></a>
 ### One To Many (Inverse)
+### 1:*(일대다) 역관계
 
 Now that we can access all of a post's comments, let's define a relationship to allow a comment to access its parent post. To define the inverse of a `hasMany` relationship, define a relationship function on the child model which calls the `belongsTo` method:
+
+이제 게시물의 모든 댓글에 접근할 수 있으니 댓글이 부모 게시물에 접근할 수 있도록 해주는 관계를 정의해 봅시다. `hasMany` 관계의 반대를 정의하려면 `belongsTo` 메소드를 호출하는 자식 모델에 관계 함수를 정의하면 됩니다:
 
     <?php
 
@@ -221,11 +294,15 @@ Now that we can access all of a post's comments, let's define a relationship to 
 
 Once the relationship has been defined, we can retrieve the `Post` model for a `Comment` by accessing the `post` "dynamic property":
 
+관계가 정의되었다면 `post` "동적 속성"에 접근하여서 `Comment`에 대한 `Post` 모델을 찾을 수 있습니다:
+
     $comment = App\Comment::find(1);
 
     echo $comment->post->title;
 
 In the example above, Eloquent will try to match the `post_id` from the `Comment` model to an `id` on the `Post` model. Eloquent determines the default foreign key name by examining the name of the relationship method and suffixing the method name with `_id`. However, if the foreign key on the `Comment` model is not `post_id`, you may pass a custom key name as the second argument to the `belongsTo` method:
+
+위의 예에서 Eloqent는 `Comment` 모델의 `post_id`와 `Post` 모델의 `id`를 비교해볼 것입니다. Eloquent는 relationship 메소드의 이름을 검사하고 메소드 이름에 `_id`를 붙여서 외래 키의 기본 이름을 결정합니다. 하지만 `Comment` 모델의 외래 키가 `post_id`가 아니라면 커스텀 키 이름을 두번째 인자로 `belongsTo`에 전달하면 됩니다:
 
     /**
      * Get the post that owns the comment.
@@ -237,6 +314,8 @@ In the example above, Eloquent will try to match the `post_id` from the `Comment
 
 If your parent model does not use `id` as its primary key, or you wish to join the child model to a different column, you may pass a third argument to the `belongsTo` method specifying your parent table's custom key:
 
+부모 모델이 `id`를 프라이머리 키로 사용하지 않거나 자식 모델을 다른 컬럼에 조인시키고 싶으면 부모 테이블의 커스텀 키를 지정하는 세번째 인자를 `belongsTo` 메소드로 전달하면 됩니다:
+
     /**
      * Get the post that owns the comment.
      */
@@ -247,10 +326,15 @@ If your parent model does not use `id` as its primary key, or you wish to join t
 
 <a name="many-to-many"></a>
 ### Many To Many
+### \*:* (다대다) 관계 정의하기
 
 Many-to-many relations are slightly more complicated than `hasOne` and `hasMany` relationships. An example of such a relationship is a user with many roles, where the roles are also shared by other users. For example, many users may have the role of "Admin". To define this relationship, three database tables are needed: `users`, `roles`, and `role_user`. The `role_user` table is derived from the alphabetical order of the related model names, and contains the `user_id` and `role_id` columns.
 
+다대다 관계는 `hasOne`과 `hasMany` 관계들에 비해서 조금 더 복잡합니다. 이런 관계의 예로 사용자가 여러 역할을 가지면서 그 역할들이 다른 사용자와 공유되는 경우가 있습니다. 예를 들어 여러 사용자들이 "Admin" 역할을 할 수 있습니다. 이 관계를 정의하기 위해는 `users`, `roles`, 그리고 `role_user`의 3개의 데이터베이스 테이블이 필요합니다. `role_user` 테이블은 관련된 모델 이름의 알파펫 순으로부터 정렬되며 `user_id`와 `role_id` 컬럼을 가지고 있습니다.
+
 Many-to-many relationships are defined by writing a method that returns the result of the `belongsToMany` method. For example, let's define the `roles` method on our `User` model:
+
+다대다 관계는 `belongsToMany` 메소드의 결과를 반환하는 메소드를 작성하여 정의합니다. 예를 들어 `User` 모델에 `roles` 메소드를 정의해보도록 하겠습니다:
 
     <?php
 
@@ -271,6 +355,8 @@ Many-to-many relationships are defined by writing a method that returns the resu
 
 Once the relationship is defined, you may access the user's roles using the `roles` dynamic property:
 
+관계가 정의되었다면 `roles` 동적 속성을 사용하여 사용자들의 역할에 접근할 수 있습니다:
+
     $user = App\User::find(1);
 
     foreach ($user->roles as $role) {
@@ -279,19 +365,28 @@ Once the relationship is defined, you may access the user's roles using the `rol
 
 Of course, like all other relationship types, you may call the `roles` method to continue chaining query constraints onto the relationship:
 
+물론 다른 모든 관계 타입과 같이 `roles` 메소드를 호출하여 관계에 대해서 쿼리 제한 조건들을 계속하여 체이닝 할 수 있습니다:
+
     $roles = App\User::find(1)->roles()->orderBy('name')->get();
 
 As mentioned previously, to determine the table name of the relationship's joining table, Eloquent will join the two related model names in alphabetical order. However, you are free to override this convention. You may do so by passing a second argument to the `belongsToMany` method:
+
+앞서 살펴본 바와같이, Eloquent는 relationship-관계의 조인(join) 테이블의 테이블 명을 결정하기 위해 관련된 두 모델 이름을 알파벳 순으로 합칠 것입니다. (user 와 role 일 경우에 role_user 로 이름을 추정합니다) 하지만 이러한 관례는 재지정 할 수 있습니다. `belongsToMany` 메소드로 두번째 인자를 전달하면 됩니다:
 
     return $this->belongsToMany('App\Role', 'role_user');
 
 In addition to customizing the name of the joining table, you may also customize the column names of the keys on the table by passing additional arguments to the `belongsToMany` method. The third argument is the foreign key name of the model on which you are defining the relationship, while the fourth argument is the foreign key name of the model that you are joining to:
 
+join 테이블의 이름을 커스터마이징하는 것 외에도 `belongsToMany` 메소드에 추가 인자들을 전달하면 키들의 이름들 또한 커스터마이징 할 수 있습니다. 세번째 인자는 관계를 정의하는 모델의 외래 키 이름이고 네번째 인자는 join 하는 모델의 외래 키 이름입니다:
+
     return $this->belongsToMany('App\Role', 'role_user', 'user_id', 'role_id');
 
 #### Defining The Inverse Of The Relationship
+#### 관계의 역(반대) 정의하기
 
 To define the inverse of a many-to-many relationship, you place another call to `belongsToMany` on your related model. To continue our user roles example, let's define the `users` method on the `Role` model:
+
+다대다 관계의 반대를 정의하려면 관련된 모델에 `belongsToMany`를 호출합니다. 사용자와 역할에 대한 예를 계속 들어 생각해서, `Role` 모델에 `users` 메소드를 정의해봅시다:
 
     <?php
 
@@ -312,9 +407,14 @@ To define the inverse of a many-to-many relationship, you place another call to 
 
 As you can see, the relationship is defined exactly the same as its `User` counterpart, with the exception of referencing the `App\User` model. Since we're reusing the `belongsToMany` method, all of the usual table and key customization options are available when defining the inverse of many-to-many relationships.
 
+위에서 볼 수 있듯이 `App\User` 모델을 참고하는 것만 제외하고 relationship-관계는 대응하는 `User`와 정확히 동일하게 정의되어 있습니다. `belongsToMany` 메소드를 재사용하고 있기 때문에 다대다 관계의 역-반대를 정의할 때에는 테이블과 키의 모든 통상적인 커스터마이즈 옵션이 사용 가능합니다.
+
 #### Retrieving Intermediate Table Columns
+#### 중간 테이블 컬럼 조회하기
 
 As you have already learned, working with many-to-many relations requires the presence of an intermediate table. Eloquent provides some very helpful ways of interacting with this table. For example, let's assume our `User` object has many `Role` objects that it is related to. After accessing this relationship, we may access the intermediate table using the `pivot` attribute on the models:
+
+앞서 알아 보았듯이, 다대다 관계는 중간 테이블의 존재를 필요로 합니다. Eloquent는 이 테이블과 상호 작용할 수 있게 도움을 주는 몇몇 방법들을 제공합니다. 예를 들어, `User` 객체가 여러 `Role` 객체에 관련되어 있다고 생각해 봅시다. 이 관계에 접근한 후 모델들에 `pivot` 속성을 사용하여 중간 테이블에 접근할 수 있습니다:
 
     $user = App\User::find(1);
 
@@ -324,25 +424,38 @@ As you have already learned, working with many-to-many relations requires the pr
 
 Notice that each `Role` model we retrieve is automatically assigned a `pivot` attribute. This attribute contains a model representing the intermediate table, and may be used like any other Eloquent model.
 
+조회되는 각 `Role` 모델은 자동으로 `pivot` 속성을 부여받습니다. 이 속성은 중간 테이블을 나타내는 모델을 포함하고 있으며 여느 Eloquent 모델과 다르지 않게 사용될 수 있습니다.
+
 By default, only the model keys will be present on the `pivot` object. If your pivot table contains extra attributes, you must specify them when defining the relationship:
+
+기본적으로 `pivot` 객체에는 모델 키만 존재할 것입니다. Pivot 테이블이 추가 속성들을 포함한다면 관계를 정의할 때 명시해야 합니다:
 
     return $this->belongsToMany('App\Role')->withPivot('column1', 'column2');
 
 If you want your pivot table to have automatically maintained `created_at` and `updated_at` timestamps, use the `withTimestamps` method on the relationship definition:
 
+Pivot 테이블이 자동으로 유지되는 `created_at`와 `updated_at` 타임스탬프를 갖기 원한다면 관계 정의에 `withTimestamps` 메소드를 사용하면 됩니다:
+
     return $this->belongsToMany('App\Role')->withTimestamps();
 
 #### Customizing The `pivot` Attribute Name
+#### `pivot` 속성의 이름 커스터마이징 하기
 
 As noted earlier, attributes from the intermediate table may be accessed on models using the `pivot` attribute. However, you are free to customize the name of this attribute to better reflect its purpose within your application.
 
+앞서 이야기 한것처럼, 모델에서 `pivot` 속성을 사용하여 중간 테이블의 속성에 엑세스 할 수 있습니다. 그렇지만 어플리케이션에서 용도를 보다 명확하게 표현할 수 있도록 속성의 이름을 자유롭게 커스터마이징 할 수 있습니다.
+
 For example, if your application contains users that may subscribe to podcasts, you probably have a many-to-many relationship between users and podcasts. If this is the case, you may wish to rename your intermediate table accessor to `subscription` instead of `pivot`. This can be done using the `as` method when defining the relationship:
+
+예를 들어, 어플리케이션에서 팟캐스트를 등록할 수 있는 사용자를 가지는 경우, 사용자와 팟캐스트는 다대다 관계를 형성할 수 있습니다. 이 경우 중간 테이블에 엑세스 하는 `pivot` 대신에 `subscription` 으로 이름을 변경할 수 있습니다. 이는 관계를 정의 할 때 `as` 메소드를 사용하여 지정하면 됩니다:
 
     return $this->belongsToMany('App\Podcast')
                     ->as('subscription')
                     ->withTimestamps();
 
 Once this is done, you may access the intermediate table data using the customized name:
+
+이 후에는, 다음과 같이 커스터마이징한 이름을 사용하여 중간 테이블에 엑세스 할 수 있습니다:
 
     $users = User::with('podcasts')->get();
 
@@ -351,16 +464,22 @@ Once this is done, you may access the intermediate table data using the customiz
     }
 
 #### Filtering Relationships Via Intermediate Table Columns
+#### 중간 테이블의 컬럼을 사용한 관계의 필터링
 
 You can also filter the results returned by `belongsToMany` using the `wherePivot` and `wherePivotIn` methods when defining the relationship:
+
+관계를 정의할 때, `wherePivot` 과 `wherePivotIn` 메소드를 사용하여 `belongsToMany`이 반환하는 결과를 필터링 할 수도 있습니다.
 
     return $this->belongsToMany('App\Role')->wherePivot('approved', 1);
 
     return $this->belongsToMany('App\Role')->wherePivotIn('priority', [1, 2]);
 
 #### Defining Custom Intermediate Table Models
+#### 커스텀 중간 테이블 모델 정의하기
 
 If you would like to define a custom model to represent the intermediate table of your relationship, you may call the `using` method when defining the relationship. All custom models used to represent intermediate tables of relationships must extend the `Illuminate\Database\Eloquent\Relations\Pivot` class. For example, we may define a `Role` which uses a custom `UserRole` pivot model:
+
+관계의 중간 테이블을 표현하기 위해서 커스텀 모델을 정의하려면, 관계를 정의할 때 `using` 메소드를 호출하면 됩니다. 관계의 중간 테이블을 나타내는 데 사용되는 모든 커스텀 모델은 `Illuminate\Database\Eloquent\Relations\Pivot` 클래스를 상속해야합니다. 예를 들어, 커스텀 `UserRole` 피벗 모델을 사용하는 `Role` 을 정의할 수 있습니다.
 
     <?php
 
@@ -381,6 +500,8 @@ If you would like to define a custom model to represent the intermediate table o
 
 When defining the `UserRole` model, we will extend the `Pivot` class:
 
+`UserRole` 모델을 정의할 때에는 `Pivot` 클래스를 상속합니다:
+
     <?php
 
     namespace App;
@@ -394,8 +515,11 @@ When defining the `UserRole` model, we will extend the `Pivot` class:
 
 <a name="has-many-through"></a>
 ### Has Many Through
+### 연결을 통한 다수를 가지는 관계 정의하기
 
 The "has-many-through" relationship provides a convenient shortcut for accessing distant relations via an intermediate relation. For example, a `Country` model might have many `Post` models through an intermediate `User` model. In this example, you could easily gather all blog posts for a given country. Let's look at the tables required to define this relationship:
+
+"연결을 통한 다수를 가지는" 관계는 중간 테이블을 통해서, 서로 떨어진 관계들에 접근하는 편리한 방법을 제공합니다. 예를 들어, `Country` 모델은 중간 `User` 모델을 통해 다수의 `Post` 모델을 가지고 있을 수 있습니다. 이 예제에서는 특정 국가에 대한 모든 블로그 게시물을 쉽게 확인할 수 있습니다. 이 관계를 정의하기 위해 요구되는 테이블들을 살펴보겠습니다:
 
     countries
         id - integer
@@ -413,7 +537,11 @@ The "has-many-through" relationship provides a convenient shortcut for accessing
 
 Though `posts` does not contain a `country_id` column, the `hasManyThrough` relation provides access to a country's posts via `$country->posts`. To perform this query, Eloquent inspects the `country_id` on the intermediate `users` table. After finding the matching user IDs, they are used to query the `posts` table.
 
+`posts`는 `country_id` 컬럼을 포함하고 있지 않지만 `hasManyThrough` 관계는 `$country->posts`를 통해 컨트리에 대한 접근을 제공합니다. 이 쿼리를 수행하기 위해 Eloquent는 중간 `users` 테이블의 `country_id`를 검사합니다. 일치하는 사용자 ID를 찾은 후에는 `posts` 테이블을 쿼리하는데 사용합니다.
+
 Now that we have examined the table structure for the relationship, let's define it on the `Country` model:
+
+relationship-관계를 위한 테이블 구조를 살펴보았으니 이제 `Country` 모델에 정의해보도록 합시다:
 
     <?php
 
@@ -434,7 +562,11 @@ Now that we have examined the table structure for the relationship, let's define
 
 The first argument passed to the `hasManyThrough` method is the name of the final model we wish to access, while the second argument is the name of the intermediate model.
 
+`hasManyThrough` 메소드로 전달되는 첫번째 인자는 접근하고자 하는 최종 모델의 이름이며 두번째 인자는 중간 모델의 이름입니다.
+
 Typical Eloquent foreign key conventions will be used when performing the relationship's queries. If you would like to customize the keys of the relationship, you may pass them as the third and fourth arguments to the `hasManyThrough` method. The third argument is the name of the foreign key on the intermediate model. The fourth argument is the name of the foreign key on the final model. The fifth argument is the local key, while the sixth argument is the local key of the intermediate model:
+
+관계의 쿼리를 수행할 때 전형적인 Eloquent 외래 키 관례들이 사용될 것입니다. 관계의 키를 사용자가 정의하고 싶다면 세번째와 네번재 인자로 `hasManyThrough` 메소드에 전달할 수 있습니다. 세번째 인자는 중간 모델의 외래 키 이름입니다. 네번째 인자는 최종 모델의 외래 키 이름입니다. 다섯번째 키는 로컬 키이고, 여섯번째 키는 중간 모델 로컬 키입니다:
 
     class Country extends Model
     {
@@ -453,10 +585,14 @@ Typical Eloquent foreign key conventions will be used when performing the relati
 
 <a name="polymorphic-relations"></a>
 ### Polymorphic Relations
+### 다형성 관계
 
 #### Table Structure
+#### 테이블 구조
 
 Polymorphic relations allow a model to belong to more than one other model on a single association. For example, imagine users of your application can "comment" both posts and videos. Using polymorphic relationships, you can use a single `comments` table for both of these scenarios. First, let's examine the table structure required to build this relationship:
+
+다형성 관계는 모델이 하나의 연관관계에 대해서 하나 이상의 모델에 소속될 수 있도록 해줍니다. 예를 들어 어플리케이션의 사용자가 게시글과 비디오 둘다 "댓글"를 달 수 있다고 생각해 보겠습니다. 다형성 관계를 이용하면 이 두 시나리오 모두 지원하는 하나의 `comments` 테이블을 사용할 수 있습니다. 먼저 이 관계를 구성하기 위해 필요한 테이블 구조를 살펴보겠습니다:
 
     posts
         id - integer
@@ -476,9 +612,14 @@ Polymorphic relations allow a model to belong to more than one other model on a 
 
 Two important columns to note are the `commentable_id` and `commentable_type` columns on the `comments` table. The `commentable_id` column will contain the ID value of the post or video, while the `commentable_type` column will contain the class name of the owning model. The `commentable_type` column is how the ORM determines which "type" of owning model to return when accessing the `commentable` relation.
 
+유심히 살펴봐야할 중요한 두개의 컬럼은 `comments` 테이블의 `commentable_id`와 `commentable_type` 컬럼입니다. `commentable_id` 컬럼은 게시글과 비디오의 ID 값을 가지고, `commentable_type` 컬럼은 소유 모델의 클래스 이름을 가집니다. `commentable_type` 컬럼은 `likeable` 관계에 접근할 때 어떤 "유형"의 소유 모델을 반환할지 ORM이 결정하는 방법입니다.
+
 #### Model Structure
+#### 모델 구조
 
 Next, let's examine the model definitions needed to build this relationship:
+
+다음으로 이 관계를 형성하기 위해 필요한 모델 정의들을 살펴보도록 하겠습니다:
 
     <?php
 
@@ -520,8 +661,11 @@ Next, let's examine the model definitions needed to build this relationship:
     }
 
 #### Retrieving Polymorphic Relations
+#### 다형성 관계 조회하기
 
 Once your database table and models are defined, you may access the relationships via your models. For example, to access all of the comments for a post, we can use the `comments` dynamic property:
+
+데이터베이스 테이블과 모델이 정의되었다면 모델들을 통해 관계들에 접근할 수 있습니다. 예를 들어, 게시글의 모든 댓글에 접근하기 위해서, `comments` 동적 속성을 사용할 수 있습니다:
 
     $post = App\Post::find(1);
 
@@ -531,15 +675,22 @@ Once your database table and models are defined, you may access the relationship
 
 You may also retrieve the owner of a polymorphic relation from the polymorphic model by accessing the name of the method that performs the call to `morphTo`. In our case, that is the `commentable` method on the `Comment` model. So, we will access that method as a dynamic property:
 
+또한 `morphTo`의 호출을 수행하는 메소드의 이름에 접근하여 다형성 모델에서 다형성 관계의 소유자를 조회할 수 있습니다. 이 경우, `Comment` 모델에 `commentable` 메소드를 사용합니다. 따라서 이 메소드를 동적 속성으로 접근할 것입니다:
+
     $comment = App\Comment::find(1);
 
     $commentable = $comment->commentable;
 
 The `commentable` relation on the `Comment` model will return either a `Post` or `Video` instance, depending on which type of model owns the comment.
 
+`Comment` 모델의 `commentabl` 관계는 댓글을 어느 모델이 소유하느냐에 따라 `Post`나 `Video` 인스턴스를 반환합니다.
+
 #### Custom Polymorphic Types
+#### 사용자 정의 다형성 타입
 
 By default, Laravel will use the fully qualified class name to store the type of the related model. For instance, given the example above where a `Comment` may belong to a `Post` or a `Video`, the default `commentable_type` would be either `App\Post` or `App\Video`, respectively. However, you may wish to decouple your database from your application's internal structure. In that case, you may define a relationship "morph map" to instruct Eloquent to use a custom name for each model instead of the class name:
+
+기본적으로, 라라벨은 관련된 모델의 유형을 저장하기 위해서 전체 클래스 이름을 사용합니다. 예를 들어 위의 예제에서 `Comment` 는 하나의 `Post` 또는 하나의 `Video` 에 지정되고, 기본적으로 `commentable_type` 의 각각 `App\Post` 또는 `App\Video` 이 될 수 있습니다. 그렇지만, 여러분은 데이터베이스와 어플리케이션의 내부 구조를 분리하고자 할 수 있습니다. 이 경우 여러분은 관계 설정을 위한 "morph map"을 정의하고 클래스 이름 대신 사용할 각각의 모델과 관련 있는 고유한 이름을 Eloquent 에 지시할 수 있습니다:
 
     use Illuminate\Database\Eloquent\Relations\Relation;
 
@@ -550,12 +701,18 @@ By default, Laravel will use the fully qualified class name to store the type of
 
 You may register the `morphMap` in the `boot` function of your `AppServiceProvider` or create a separate service provider if you wish.
 
+여러분은 `AppServiceProvider` 의 `boot` 안에서 `morphMap` 를 등록 하거나, 원한다면 분리된 서비스 프로바이더를 만들 수도 있을 것입니다.
+
 <a name="many-to-many-polymorphic-relations"></a>
 ### Many To Many Polymorphic Relations
+### 다대다 다형성 관계 정의하기
 
 #### Table Structure
+#### 테이블 구조
 
 In addition to traditional polymorphic relations, you may also define "many-to-many" polymorphic relations. For example, a blog `Post` and `Video` model could share a polymorphic relation to a `Tag` model. Using a many-to-many polymorphic relation allows you to have a single list of unique tags that are shared across blog posts and videos. First, let's examine the table structure:
+
+일반적인 다형성 관계 말고도 "다대다" 다형성 관계 또한 정의할 수 있습니다. 예를 들어, 블로그 `Post`와 `Video` 모델은 `Tag` 모델과 다형성 관계를 공유할 수 있습니다. 다대다 다형성 관계를 사용하면 블로그 게시물과 비디오를 아울러 공유되는 고유의 태그를 하나의 목록으로 만들어줍니다. 우선 테이블 구조를 살펴보겠습니다:
 
     posts
         id - integer
@@ -575,8 +732,11 @@ In addition to traditional polymorphic relations, you may also define "many-to-m
         taggable_type - string
 
 #### Model Structure
+#### 모델 구조
 
 Next, we're ready to define the relationships on the model. The `Post` and `Video` models will both have a `tags` method that calls the `morphToMany` method on the base Eloquent class:
+
+이제 모델에 관계를 정의할 준비가 되었습니다. `Post`와 `Video` 모델은 둘 다 Eloquent 클래스에 `morphToMany` 메소드를 호출하는 `tags` 메소드를 가집니다:
 
     <?php
 
@@ -596,8 +756,11 @@ Next, we're ready to define the relationships on the model. The `Post` and `Vide
     }
 
 #### Defining The Inverse Of The Relationship
+#### 역관계 정의하기
 
 Next, on the `Tag` model, you should define a method for each of its related models. So, for this example, we will define a `posts` method and a `videos` method:
+
+다음, `Tag` 모델에서 관련된 각 모델들을 위해 메소드를 정의해야 합니다. 이 예제에서는 `posts` 메소드와 `videos` 메소드를 정의하겠습니다:
 
     <?php
 
@@ -625,8 +788,11 @@ Next, on the `Tag` model, you should define a method for each of its related mod
     }
 
 #### Retrieving The Relationship
+#### 관계 조회하기
 
 Once your database table and models are defined, you may access the relationships via your models. For example, to access all of the tags for a post, you can use the `tags` dynamic property:
+
+데이터베이스 테이블과 모델들이 정의되었다면 모델을 통해 관계에 접근할 수 있습니다. 예를 들어, 어떤 게시물의 모든 태그에 접근하려면, `tags` 동적 속성을 사용하면 됩니다:
 
     $post = App\Post::find(1);
 
@@ -636,6 +802,8 @@ Once your database table and models are defined, you may access the relationship
 
 You may also retrieve the owner of a polymorphic relation from the polymorphic model by accessing the name of the method that performs the call to `morphedByMany`. In our case, that is the `posts` or `videos` methods on the `Tag` model. So, you will access those methods as dynamic properties:
 
+또한 `morphedByMany`의 호출을 수행하는 메소드의 이름에 접근하여 다형성 모델에서 다형성 관계의 소유자를 조회할 수 있습니다. 이 예에서는 `Tag` 모델에 사용되는`posts`나 `videos` 메소드를 말합니다. 따라서 이 메소드들은 동적 속성으로 접근할 것입니다:
+
     $tag = App\Tag::find(1);
 
     foreach ($tag->videos as $video) {
@@ -644,10 +812,15 @@ You may also retrieve the owner of a polymorphic relation from the polymorphic m
 
 <a name="querying-relations"></a>
 ## Querying Relations
+## 관계 쿼리 질의하기
 
 Since all types of Eloquent relationships are defined via methods, you may call those methods to obtain an instance of the relationship without actually executing the relationship queries. In addition, all types of Eloquent relationships also serve as [query builders](/docs/{{version}}/queries), allowing you to continue to chain constraints onto the relationship query before finally executing the SQL against your database.
 
+모든 Eloquent 관계는 메소드를 통해 정의되기 때문에, 관계 쿼리를 실제로 실행하는 대신에 이 메소드을 호출하여 관계 인스턴스를 가져올 수 있습니다. 모든 종류의 Eloquent 모델들은 또한 [쿼리 빌더](/docs/{{version}}/queries)의 역할을 하기 때문에 데이터베이스에 최종적으로 SQL을 실행하기 전에 관계 쿼리에 제한(where 구문)을 체이닝(호출->호출->호출 형태의 질의) 할 수 있도록 해줍니다.
+
 For example, imagine a blog system in which a `User` model has many associated `Post` models:
+
+예를 들어, `User` 모델이 다수의 `Post` 모델에 연관되어 있는 블로그 시스템을 상상해 봅시다:
 
     <?php
 
@@ -668,16 +841,23 @@ For example, imagine a blog system in which a `User` model has many associated `
 
 You may query the `posts` relationship and add additional constraints to the relationship like so:
 
+다음과 같이 `posts` 관계들을 쿼리하고 관계에 제한들을 추가할 수 있습니다:
+
     $user = App\User::find(1);
 
     $user->posts()->where('active', 1)->get();
 
 You are able to use any of the [query builder](/docs/{{version}}/queries) methods on the relationship, so be sure to explore the query builder documentation to learn about all of the methods that are available to you.
 
+관계에 대해서 어떠한 [쿼리 빌더](/docs/{{version}}/queries) 메소드도 사용 가능하기 때문에, 가능한 메소드들에 대해서 확인하려면 쿼리 빌더에 대한 문서를 확인하시기 바랍니다.
+
 <a name="relationship-methods-vs-dynamic-properties"></a>
 ### Relationship Methods Vs. Dynamic Properties
+### 관계 메소드 Vs. 동적 속성
 
 If you do not need to add additional constraints to an Eloquent relationship query, you may access the relationship as if it were a property. For example, continuing to use our `User` and `Post` example models, we may access all of a user's posts like so:
+
+Eloquent 관계 쿼리에 제한을 추가할 필요가 없다면 속성처럼 관계에 접근할 수 있습니다. 예를 들어, `User`와 `Post` 예시 모델들을 계속해서 사용하면 다음과 같이 사용자의 모든 게시물에 접근할 수 있습니다:
 
     $user = App\User::find(1);
 
@@ -687,25 +867,36 @@ If you do not need to add additional constraints to an Eloquent relationship que
 
 Dynamic properties are "lazy loading", meaning they will only load their relationship data when you actually access them. Because of this, developers often use [eager loading](#eager-loading) to pre-load relationships they know will be accessed after loading the model. Eager loading provides a significant reduction in SQL queries that must be executed to load a model's relations.
 
+동적 속성은 "지연 로딩"으로, 실제로 엑세스를 해야만 관계 데이터를 로드합니다. 그렇게 때문에 개발자들은 종종 모델을 로드한 뒤 접근해야할 관계들을 미리 로드해주는 [eager 로딩](#eager-loading)을 사용합니다. Eager 로딩은 모델의 관계를 로드하기 위해 실행되어야 할 SQL 쿼리들을 유의미하게 줄여줍니다.
+
 <a name="querying-relationship-existence"></a>
 ### Querying Relationship Existence
+### 관계의 존재 여부 쿼리 질의하기
 
 When accessing the records for a model, you may wish to limit your results based on the existence of a relationship. For example, imagine you want to retrieve all blog posts that have at least one comment. To do so, you may pass the name of the relationship to the `has` and `orHas` methods:
+
+모델의 기록에 접근할 때, 관계의 존재 여부에 따라 결과를 제한하기 원할 수 있습니다. 예를 들어 하나 이상의 댓글을 가진 모든 블로그 게시물을 조회하려고 한다고 생각해 봅시다. 이를 위해서 `has` 또는 `orHas` 메소드로 관계의 이름을 전달할 수 있습니다:
 
     // Retrieve all posts that have at least one comment...
     $posts = App\Post::has('comments')->get();
 
 You may also specify an operator and count to further customize the query:
 
+또한 메소드에서 사용할 수 있는 연산자와 카운트 갯수를 지정하여 쿼리를 계속하여 커스터마이즈할 수 있습니다:
+
     // Retrieve all posts that have three or more comments...
     $posts = App\Post::has('comments', '>=', 3)->get();
 
 Nested `has` statements may also be constructed using "dot" notation. For example, you may retrieve all posts that have at least one comment and vote:
 
+중첩된 `has` 구문(statement)은 "점(.)" 표기를 사용하여 구성될 수 있습니다. 예를 들어, 최소한 하나의 댓글과 좋아요(vote)를 가진 모든 게시물을 조회할 수 있습니다:
+
     // Retrieve all posts that have at least one comment with votes...
     $posts = App\Post::has('comments.votes')->get();
 
 If you need even more power, you may use the `whereHas` and `orWhereHas` methods to put "where" conditions on your `has` queries. These methods allow you to add customized constraints to a relationship constraint, such as checking the content of a comment:
+
+더 많은 권한이 필요하다면 `whereHas`와 `orWhereHas` 메소드를 사용하여 `has` 쿼리에 "where" 조건을 추가할 수 있습니다. 이 메소드들은 관계 제한에 댓글 컨텐츠 확인과 같은 사용자 정의된 제한들을 추가할 수 있게 해줍니다:
 
     // Retrieve all posts with at least one comment containing words like foo%
     $posts = App\Post::whereHas('comments', function ($query) {
@@ -714,12 +905,17 @@ If you need even more power, you may use the `whereHas` and `orWhereHas` methods
 
 <a name="querying-relationship-absence"></a>
 ### Querying Relationship Absence
+### 관계된 모델이 존재하지 않는 것을 확인하며 질의하기
 
 When accessing the records for a model, you may wish to limit your results based on the absence of a relationship. For example, imagine you want to retrieve all blog posts that **don't** have any comments. To do so, you may pass the name of the relationship to the `doesntHave` and `orDoesntHave` methods:
+
+모델의 레코드에 엑세스 할 때, 관계된 모델이 존재하지 않는 것에 따라서 결과를 제한하고자 할 수 있습니다. 예를 들어 코멘트를 가지고 있지 **않은** 모든 블로그 포스트를 조회하는 경우를 생각해 보겠습니다. 이렇게 하기 위해서는 `doesntHave` 또는 `orDoesntHave` 메소드에 정의한 관계의 이름을 전달하면됩니다:
 
     $posts = App\Post::doesntHave('comments')->get();
 
 If you need even more power, you may use the `whereDoesntHave` and `orWhereDoesntHave` methods to put "where" conditions on your `doesntHave` queries. These methods allows you to add customized constraints to a relationship constraint, such as checking the content of a comment:
+
+더 강력한 기능을 원한다면, `doesntHave` 쿼리에 "where" 조건을 붙여서, `whereDoesntHave` 와 `orWhereDoesntHave` 메소드를 사용할 수 있습니다. 이 메소드는 코멘트의 내용을 확인하는 것과 같이 관계 제약에 커스터마이징된 제약을 추가해준다.
 
     $posts = App\Post::whereDoesntHave('comments', function ($query) {
         $query->where('content', 'like', 'foo%');
@@ -727,8 +923,11 @@ If you need even more power, you may use the `whereDoesntHave` and `orWhereDoesn
 
 <a name="counting-related-models"></a>
 ### Counting Related Models
+### 연관된 모델의 갯수 확인하기-카운팅
 
 If you want to count the number of results from a relationship without actually loading them you may use the `withCount` method, which will place a `{relation}_count` column on your resulting models. For example:
+
+관계 결과의 갯수를 실제 레코드를 로딩하지 않고 알고자 한다면, `withCount` 메소드를 사용하여 건수는 결과 모델의 `{관계}_count` 컬럼에 위치하도록 할 수 있습니다. 예를 들어:
 
     $posts = App\Post::withCount('comments')->get();
 
@@ -738,6 +937,8 @@ If you want to count the number of results from a relationship without actually 
 
 You may add the "counts" for multiple relations as well as add constraints to the queries:
 
+다수의 관계에 대해서도 쿼리에 제약을 추가하여 "갯수"를 조회할 수 있습니다.
+
     $posts = App\Post::withCount(['votes', 'comments' => function ($query) {
         $query->where('content', 'like', 'foo%');
     }])->get();
@@ -746,6 +947,8 @@ You may add the "counts" for multiple relations as well as add constraints to th
     echo $posts[0]->comments_count;
 
 You may also alias the relationship count result, allowing multiple counts on the same relationship:
+
+동일한 관계에 대하여 여러번 카운트를 수행하기 위해서 카운트 결과에 별칭(alias)를 부여할 수도 있습니다:
 
     $posts = App\Post::withCount([
         'comments',
@@ -760,8 +963,11 @@ You may also alias the relationship count result, allowing multiple counts on th
 
 <a name="eager-loading"></a>
 ## Eager Loading
+## Eager 로딩
 
 When accessing Eloquent relationships as properties, the relationship data is "lazy loaded". This means the relationship data is not actually loaded until you first access the property. However, Eloquent can "eager load" relationships at the time you query the parent model. Eager loading alleviates the N + 1 query problem. To illustrate the N + 1 query problem, consider a `Book` model that is related to `Author`:
+
+Eloquent 관계들을 속성으로 접근할 때 관계 데이터는 "지연 로드" 되어있습니다. 이는 속성에 엑세스 하기 전까지 관계 데이터가 실제로 로드되지 않는다는 것을 의미합니다. 하지만 Eloquent는 부모 모델을 쿼리할 때 관계를 "eager 로드"할 수도 있습니다. Eager 로딩은 N + 1 쿼리 문제를 해결 합니다. N + 1 쿼리 문제에 대한 예제를 들어보자면 `Author`에 연관된 `Book` 모델을 생각해볼 수 있습니다:
 
     <?php
 
@@ -782,6 +988,8 @@ When accessing Eloquent relationships as properties, the relationship data is "l
 
 Now, let's retrieve all books and their authors:
 
+이제 모든 책과 그 저자들을 조회해봅시다:
+
     $books = App\Book::all();
 
     foreach ($books as $book) {
@@ -790,7 +998,11 @@ Now, let's retrieve all books and their authors:
 
 This loop will execute 1 query to retrieve all of the books on the table, then another query for each book to retrieve the author. So, if we have 25 books, this loop would run 26 queries: 1 for the original book, and 25 additional queries to retrieve the author of each book.
 
+이 반복문은 테이블에서 모든 책들을 조회하는 1 개의 쿼리를 실행하고, 각각의 책마다 저자를 조회하는 별개의 쿼리를 실행할 것입니다. 따라서, 만약 25개의 책이 있다면, 이 반복문은 원래 책을 위한 하나의 쿼리와 각 책의 저자를 조회하는 25개의 추가적인 쿼리, 총 26개의 쿼리를 실행하게 됩니다.
+
 Thankfully, we can use eager loading to reduce this operation to just 2 queries. When querying, you may specify which relationships should be eager loaded using the `with` method:
+
+다행히도, eager 로딩을 사용하면 이 작업을 2개의 쿼리로 줄일 수 있습니다. 쿼리를 실행할 때 `with` 메소드를 사용하여 어떤 관계가 eager 로드되어야 하는지 지정할 수 있습니다:
 
     $books = App\Book::with('author')->get();
 
@@ -800,34 +1012,50 @@ Thankfully, we can use eager loading to reduce this operation to just 2 queries.
 
 For this operation, only two queries will be executed:
 
+이 작업에서는 두 개의 쿼리만이 실행될 것입니다:
+
     select * from books
 
     select * from authors where id in (1, 2, 3, 4, 5, ...)
 
 #### Eager Loading Multiple Relationships
+#### 여러 관계에 대해서 Eager 로딩하기
 
 Sometimes you may need to eager load several different relationships in a single operation. To do so, just pass additional arguments to the `with` method:
+
+종종 하나의 작업에서 여러 개의 다른 관계들을 eager 로드해야 될 때가 있습니다. 이 경우 `with` 메소드에 추가 인자들을 전달하면 됩니다:
 
     $books = App\Book::with(['author', 'publisher'])->get();
 
 #### Nested Eager Loading
+#### 중첩된 Eager 로딩하기
 
 To eager load nested relationships, you may use "dot" syntax. For example, let's eager load all of the book's authors and all of the author's personal contacts in one Eloquent statement:
+
+"점" 구문을 이용하면 중첩된 관계들을 eager 로드할 수 있습니다. 예를 들어, 하나의 Eloquent 구문(statement)에서 책의 모든 저자들과 저자들의 모든 연락처를 eager 로드해보겠습니다:
 
     $books = App\Book::with('author.contacts')->get();
 
 #### Eager Loading Specific Columns
+#### Eager 로딩에서 컬럼 지정하기
 
 You may not always need every column from the relationships you are retrieving. For this reason, Eloquent allows you to specify which columns of the relationship you would like to retrieve:
+
+조회하고자 하는 관계에서 항상 모든 컬럼이 필요한 것은 아닙니다. 이 경우, Eloquent 는 조회하고자 하는 관계에 컬럼을 지정할 수 있습니다:
 
     $users = App\Book::with('author:id,name')->get();
 
 > {note} When using this feature, you should always include the `id` column in the list of columns you wish to retrieve.
 
+> {note} 이 기능을 사용할 때에는, 조회하고자 하는 컬럼에 항상 `id` 컬럼이 포함되어 있어야 합니다.
+
 <a name="constraining-eager-loads"></a>
 ### Constraining Eager Loads
+### Eager 로딩에서 조건을 통해 질의 제한하기
 
 Sometimes you may wish to eager load a relationship, but also specify additional query constraints for the eager loading query. Here's an example:
+
+때로는 관계를 eager 로드하면서 eager 로딩 쿼리에 추가적인 쿼리 제한들을 지정하고 싶을 수 있습니다. 다음은 그 예제입니다:
 
     $users = App\User::with(['posts' => function ($query) {
         $query->where('title', 'like', '%first%');
@@ -835,14 +1063,19 @@ Sometimes you may wish to eager load a relationship, but also specify additional
 
 In this example, Eloquent will only eager load posts where the post's `title` column contains the word `first`. Of course, you may call other [query builder](/docs/{{version}}/queries) methods to further customize the eager loading operation:
 
+이 예제에서 Eloquent는 게시물의 `title` 컬럼이 `first`라는 단어를 포함할 때만 게시물을 eager 로드할 것입니다. 물론 다른 [쿼리 빌더](/docs/{{version}}/queries)메소드를 호출하여 계속하여서 eager 로딩 작업을 커스터마이즈할 수 있습니다:
+
     $users = App\User::with(['posts' => function ($query) {
         $query->orderBy('created_at', 'desc');
     }])->get();
 
 <a name="lazy-eager-loading"></a>
 ### Lazy Eager Loading
+### 지연 Eager 로딩
 
 Sometimes you may need to eager load a relationship after the parent model has already been retrieved. For example, this may be useful if you need to dynamically decide whether to load related models:
+
+종종 부모 모델이 조회된 후에 관계를 eager 로드해야할 필요가 있을 수 있습니다. 예를 들자면, 연관된 모델들을 동적으로 결정해야할 때 유용하게 사용됩니다:
 
     $books = App\Book::all();
 
@@ -852,11 +1085,15 @@ Sometimes you may need to eager load a relationship after the parent model has a
 
 If you need to set additional query constraints on the eager loading query, you may pass an array keyed by the relationships you wish to load. The array values should be `Closure` instances which receive the query instance:
 
+Eager 로딩 쿼리에 추가적인 쿼리 제한을 지정해야 할 경우, `load` 메소드에 로그하고자 하는 관계에 대한 키로 구성된 배열을 전달할 수 있습니다. 이 배열의 값은 쿼리 인스턴스를 인자로 받아들이는 `Closure`이어야만 합니다:
+
     $books->load(['author' => function ($query) {
         $query->orderBy('published_date', 'asc');
     }]);
 
 To load a relationship only when it has not already been loaded, use the `loadMissing` method:
+
+로딩되어 있지 않았을 때에만 관계 모델을 로딩하려면 `loadMissing` 메소드를 사용하면됩니다:
 
     public function format(Book $book)
     {
@@ -870,11 +1107,15 @@ To load a relationship only when it has not already been loaded, use the `loadMi
 
 <a name="inserting-and-updating-related-models"></a>
 ## Inserting & Updating Related Models
+## 연관된 모델 삽입하기 & 수정하기
 
 <a name="the-save-method"></a>
 ### The Save Method
+### Save 메소드
 
 Eloquent provides convenient methods for adding new models to relationships. For example, perhaps you need to insert a new `Comment` for a `Post` model. Instead of manually setting the `post_id` attribute on the `Comment`, you may insert the `Comment` directly from the relationship's `save` method:
+
+Eloquentsms 관계에 새로운 모델을 추가하는 편리한 메소드들을 제공합니다. 예를 들어, `Post` 모델에 새로운 `Comment`를 추가해야 할 수 있습니다. `Comment`에 수동으로 `post_id` 속성을 지정하는 대신 관계에 `save` 메소드에서 바로 `Comment`를 추가할 수 있습니다:
 
     $comment = new App\Comment(['message' => 'A new comment.']);
 
@@ -884,7 +1125,11 @@ Eloquent provides convenient methods for adding new models to relationships. For
 
 Notice that we did not access the `comments` relationship as a dynamic property. Instead, we called the `comments` method to obtain an instance of the relationship. The `save` method will automatically add the appropriate `post_id` value to the new `Comment` model.
 
+`comments` 관계를 동적 속성으로 접근하지 않았다는 점에 주목 하십시오. 대신에 `comments` 메소드를 호출하여 관계의 인스턴를 얻었습니다. `save` 메소드는 자동으로 새로운 `Comment` 모델에 적절한 `post_id` 값을 추가할 것입니다.
+
 If you need to save multiple related models, you may use the `saveMany` method:
+
+여러 개의 관련된 모델을 저장해야 한다면 `saveMany` 메소드를 사용하세요:
 
     $post = App\Post::find(1);
 
@@ -895,8 +1140,11 @@ If you need to save multiple related models, you may use the `saveMany` method:
 
 <a name="the-create-method"></a>
 ### The Create Method
+### Create 메소드
 
 In addition to the `save` and `saveMany` methods, you may also use the `create` method, which accepts an array of attributes, creates a model, and inserts it into the database. Again, the difference between `save` and `create` is that `save` accepts a full Eloquent model instance while `create` accepts a plain PHP `array`:
+
+`save`와 `saveMany` 메소드 외에도 속성을 배열을 받아들이고 모델을 생성하여 데이터베이스에 삽입하는 `create` 메소드를 사용하실 수 있습니다. `save`는 완전한 Eloquent 모델 인스턴스를 받아들이는 데 반해 `create`는 순수 PHP `배열`를 받는 다는 점에서 차이가 있습니다:
 
     $post = App\Post::find(1);
 
@@ -906,7 +1154,11 @@ In addition to the `save` and `saveMany` methods, you may also use the `create` 
 
 > {tip} Before using the `create` method, be sure to review the documentation on attribute [mass assignment](/docs/{{version}}/eloquent#mass-assignment).
 
+{팁} `create` 메소드를 사용하기 전에 [대량 할당-mass assignment](/docs/{{version}}/eloquent#mass-assignment) 문서를 반드시 확인하시기 바랍니다.
+
 You may use the `createMany` method to create multiple related models:
+
+`createMany` 메소드를 사용해서 여러 개의 관련된 모델을 만들 수 있습니다:
 
     $post = App\Post::find(1);
 
@@ -919,10 +1171,14 @@ You may use the `createMany` method to create multiple related models:
         ],
     ]);
 
+
 <a name="updating-belongs-to-relationships"></a>
 ### Belongs To Relationships
+### Belongs To 관계
 
 When updating a `belongsTo` relationship, you may use the `associate` method. This method will set the foreign key on the child model:
+
+`belongsTo` 관계를 변경 할 때 `associate` 메소드를 사용할 수 있습니다. 이 메소드는 자식 모델에 외래 키를 지정합니다:
 
     $account = App\Account::find(10);
 
@@ -932,16 +1188,22 @@ When updating a `belongsTo` relationship, you may use the `associate` method. Th
 
 When removing a `belongsTo` relationship, you may use the `dissociate` method. This method will set the relationship's foreign key to `null`:
 
+`belongsTo` 관계를 제거할 때는 `dissociate` 메소드를 사용하시면 됩니다. 이 메소드는 외래 키를 `null` 로 설정할 것입니다:
+
     $user->account()->dissociate();
 
     $user->save();
 
 <a name="updating-many-to-many-relationships"></a>
 ### Many To Many Relationships
+### 다대다 관계
 
 #### Attaching / Detaching
+#### 추가하기 / 분리하기
 
 Eloquent also provides a few additional helper methods to make working with related models more convenient. For example, let's imagine a user can have many roles and a role can have many users. To attach a role to a user by inserting a record in the intermediate table that joins the models, use the `attach` method:
+
+Eloquent는 또한 연관된 모델들을 다루는 데 편리한 몇 개의 헬퍼 메소드를 추가로 제공합니다. 예를 들어 한 사용자가 여러 역할을 가질 수 있고 한 역할이 여러 사용자를 갖는다고 상상해봅시다. 모델들을 합치는 중간 테이블에 기록을 추가하여 사용자에게 역할을 추가하려면 `attach` 메소드를 사용하세요:
 
     $user = App\User::find(1);
 
@@ -949,9 +1211,13 @@ Eloquent also provides a few additional helper methods to make working with rela
 
 When attaching a relationship to a model, you may also pass an array of additional data to be inserted into the intermediate table:
 
+모델에 관계를 추가할 때 중간 테이블에 삽입될 추가 데이터의 배열을 전달할 수도 있습니다:
+
     $user->roles()->attach($roleId, ['expires' => $expires]);
 
 Of course, sometimes it may be necessary to remove a role from a user. To remove a many-to-many relationship record, use the `detach` method. The `detach` method will remove the appropriate record out of the intermediate table; however, both models will remain in the database:
+
+물론 경우에 따라 사용자에게서 역할을 분리하는 것이 필요할 수 있습니다. 다대다 관계 기록을 제거하려면 `detach` 메소드를 이용하면 됩니다. `detach` 메소드는 중간 테이블에서 적절한 기록을 삭제할 것입니다. 하지만 두 모델은 모두 데이터베이스에 남을 것입니다:
 
     // Detach a single role from the user...
     $user->roles()->detach($roleId);
@@ -960,6 +1226,8 @@ Of course, sometimes it may be necessary to remove a role from a user. To remove
     $user->roles()->detach();
 
 For convenience, `attach` and `detach` also accept arrays of IDs as input:
+
+보다 편리하게, `attach`와 `detach` ID의 배열 또한 입력으로 전달 받습니다:
 
     $user = App\User::find(1);
 
@@ -971,34 +1239,50 @@ For convenience, `attach` and `detach` also accept arrays of IDs as input:
     ]);
 
 #### Syncing Associations
+#### 연결 동기화
 
 You may also use the `sync` method to construct many-to-many associations. The `sync` method accepts an array of IDs to place on the intermediate table. Any IDs that are not in the given array will be removed from the intermediate table. So, after this operation is complete, only the IDs in the given array will exist in the intermediate table:
+
+다대다 관계를 생성하기 위해 `sync` 메소드를 사용할 수도 있습니다. `sync` 메소드는 중간 테이블에 놓을 ID의 배열을 전달 받습니다. 주어진 배열에 포함되어 있지 않는 ID는 중간 테이블에서 제거됩니다. 따라서 이 작업이 끝나면 주어진 배열에 포함된 ID들만이 중간 테이블에 존재할 것입니다:
 
     $user->roles()->sync([1, 2, 3]);
 
 You may also pass additional intermediate table values with the IDs:
 
+ID들과 함께 중간 테이블 값을 추가로 전달할 수도 있습니다:
+
     $user->roles()->sync([1 => ['expires' => true], 2, 3]);
 
 If you do not want to detach existing IDs, you may use the `syncWithoutDetaching` method:
 
+존재하는 ID들을 삭제하고 싶지 않으면, `syncWithoutDetaching` 메소드를 사용하면 됩니다:
+
     $user->roles()->syncWithoutDetaching([1, 2, 3]);
 
 #### Toggling Associations
+#### 연결 켜고 끄기(토클)
 
 The many-to-many relationship also provides a `toggle` method which "toggles" the attachment status of the given IDs. If the given ID is currently attached, it will be detached. Likewise, if it is currently detached, it will be attached:
+
+다대다 관계는 또한 주어진 ID들의 추가된 상태를 "전환"할 수 있는 `toggle` 메소드를 제공합니다. 만약 주어진 ID가 현재 추가되었다면, 이는 해제될것이고 마찬가지로 현재 추가되지 않은 상태라면 추가됩니다:
 
     $user->roles()->toggle([1, 2, 3]);
 
 #### Saving Additional Data On A Pivot Table
+#### 피벗 테이블에서 추가직인 데이터 저장하기
 
 When working with a many-to-many relationship, the `save` method accepts an array of additional intermediate table attributes as its second argument:
+
+다대다 관계를 작업할 때, `save` 메소드는 두번째 인자로 추가적인 중간 테이블의 속성에 대한 배열을 받아 들입니다.
 
     App\User::find(1)->roles()->save($role, ['expires' => $expires]);
 
 #### Updating A Record On A Pivot Table
+#### 피벗 테이블 레코드 수정하기
 
 If you need to update an existing row in your pivot table, you may use `updateExistingPivot` method. This method accepts the pivot record foreign key and an array of attributes to update:
+
+피벗 테이블에 존재하는 레코드를 수정할 필요가 있다면, `updateExistingPivot` 메소드를 사용하면 됩니다. 이 메소드는 피벗 테이블의 외래 키와 수정하려는 속성에 대한 배열을 인자로 받습니다:
 
     $user = App\User::find(1);
 
@@ -1006,8 +1290,11 @@ If you need to update an existing row in your pivot table, you may use `updateEx
 
 <a name="touching-parent-timestamps"></a>
 ## Touching Parent Timestamps
+## 부모의 타임스탬프 값 갱신
 
 When a model `belongsTo` or `belongsToMany` another model, such as a `Comment` which belongs to a `Post`, it is sometimes helpful to update the parent's timestamp when the child model is updated. For example, when a `Comment` model is updated, you may want to automatically "touch" the `updated_at` timestamp of the owning `Post`. Eloquent makes it easy. Just add a `touches` property containing the names of the relationships to the child model:
+
+`Post`에 속하는 `Comment`와 같이 한 모델이 다른 모델에 `belongsTo`하거나 `belongsToMany`할 때, 자식 모델이 업데이트되었을 때 부모의 타임스탬프를 갱신하는 것이 유용할 수 있습니다. 예를 들어 `Comment` 모델이 업데이트되었을 때, 소유하는 `Post`의 `updated_at` 타임스탬프의 값을 자동으로 갱신하고자 할 수 있습니다. Eloquent는 이를 손쉽게 할 수 있게 해줍니다. 단순히 자식 모델에 관계의 이름들을 포함하는 `touches` 속성을 추가하면 됩니다.
 
     <?php
 
@@ -1034,6 +1321,8 @@ When a model `belongsTo` or `belongsToMany` another model, such as a `Comment` w
     }
 
 Now, when you update a `Comment`, the owning `Post` will have its `updated_at` column updated as well, making it more convenient to know when to invalidate a cache of the `Post` model:
+
+이제 `Comment`를 업데이트할 때 소유하는 `Post`의 `updated_at` 컬럼 또한 업데이트될 것이고, 이렇게 하는 것은 `Post` 모델의 캐시가 갱신되는 편리한 방법이기도 합니다:
 
     $comment = App\Comment::find(1);
 

--- a/kr/eloquent-resources.md
+++ b/kr/eloquent-resources.md
@@ -1,33 +1,55 @@
 # Eloquent: API Resources
+# Eloquent: API Resources
 
 - [Introduction](#introduction)
+- [소개하기](#introduction)
 - [Generating Resources](#generating-resources)
+- [리소스 클래스 생성하기](#generating-resources)
 - [Concept Overview](#concept-overview)
+- [컨셉 살펴보기](#concept-overview)
 - [Writing Resources](#writing-resources)
+- [리소스 클래스 작성하기](#writing-resources)
     - [Data Wrapping](#data-wrapping)
+    - [데이터 Wrapping(랩핑)](#data-wrapping)
     - [Pagination](#pagination)
+    - [페이지네이션](#pagination)
     - [Conditional Attributes](#conditional-attributes)
+    - [조건에 따른 속성값 표현](#conditional-attributes)
     - [Conditional Relationships](#conditional-relationships)
+    - [조건에 따른 관계 표현](#conditional-relationships)
     - [Adding Meta Data](#adding-meta-data)
+    - [메타 데이터 추가하기](#adding-meta-data)
 - [Resource Responses](#resource-responses)
+- [리소스 응답](#resource-responses)
 
 <a name="introduction"></a>
 ## Introduction
+## 소개하기
 
 When building an API, you may need a transformation layer that sits between your Eloquent models and the JSON responses that are actually returned to your application's users. Laravel's resource classes allow you to expressively and easily transform your models and model collections into JSON.
 
+API 를 작성할 때, 어플리케이션의 사용자에게 Eloquent 모델을 JSON response로 전달해주기 위한 변환 레이어(transformation layer)가 필요할 수 있습니다. 라라벨의 리소스 클래스는 손쉽게 이 모델과 모델 컬렉션을 JSON으로 표현하도록 지원해줍니다.
+
 <a name="generating-resources"></a>
 ## Generating Resources
+## 리소스 클래스 생성하기
 
 To generate a resource class, you may use the `make:resource` Artisan command. By default, resources will be placed in the `app/Http/Resources` directory of your application. Resources extend the `Illuminate\Http\Resources\Json\Resource` class:
+
+리소스 클래스를 생성하기 위해서는 `make:resource` 아티즌 명령어를 사용하면 됩니다. 기본적으로 리소스 클래스는 어플리케이션의 `app/Http/Resources` 디렉토리에 생성됩니다. 모든 리소스 클래스는 `Illuminate\Http\Resources\Json\Resource` 클래스를 상속받습니다:
 
     php artisan make:resource UserResource
 
 #### Resource Collections
+#### 리소스 컬렉션
 
 In addition to generating resources that transform individual models, you may generate resources that are responsible for transforming collections of models. This allows your response to include links and other meta information that is relevant to an entire collection of a given resource.
 
+개별적인 모델을 변환하는 것에 더해서, 모델의 컬렉션을 표현하기 위한 리소스 클래스를 생성할 수 있습니다. 이렇게 하면 지정된 리소스에 대한 응답-response에 주어진 모델 컬렉션과 연관된 링크 또는 기타 메타 정보를 포함시킬 수 있습니다.
+
 To create a resource collection, you should use the `--collection` flag when creating the resource. Or, including the word `Collection` in the resource name will indicate to Laravel that it should create a collection resource. Collection resources extend the `Illuminate\Http\Resources\Json\ResourceCollection` class:
+
+리소스 컬렉션 클래스를 생성하기 위해서는 리소스 클래스를 생성할 때 `--collection` 플래그를 지정하면 됩니다. 또는 리소스 클래스를 생성할 때, 이름에 `Collection` 라는 단어가 포함되어 있으면, 라라벨은 이를 자동으로 컬렉션을 위한 리소스 클래스로 생성합니다. 모든 컬렉션 리소스 클래스는 `Illuminate\Http\Resources\Json\ResourceCollection` 클래스를 상속받습니다:
 
     php artisan make:resource Users --collection
 
@@ -35,10 +57,15 @@ To create a resource collection, you should use the `--collection` flag when cre
 
 <a name="concept-overview"></a>
 ## Concept Overview
+## 컨셉 살펴보기
 
 > {tip} This is a high-level overview of resources and resource collections. You are highly encouraged to read the other sections of this documentation to gain a deeper understanding of the customization and power offered to you by resources.
 
+> {tip} 아래 내용은 리소스 클래스와 리소스 컬렉션 클래스에 대한 개괄적인 내용입니다. 리소스에 대한 커스터마이징과 기능에 대한 자세한 내용은 이 문서의 다른 영역을 참고하십시오.
+
 Before diving into all of the options available to you when writing resources, let's first take a high-level look at how resources are used within Laravel. A resource class represents a single model that needs to be transformed into a JSON structure. For example, here is a simple `UserResource` class:
+
+리소스 클래스를 작성할 때 사용가능한 모든 옵션들을 살펴보기 전에, 먼저 라라벨에서 리소를 사용하는 방법을 개괄적으로 알아보겠습니다. 하나의 리소스 클래스는 JSON으로 변환하고자 하는 하나의 모델을 나타냅니다. 예를 들어 다음은 `UserResource` 에 대한 리소스 클래스 입니다:
 
     <?php
 
@@ -68,6 +95,8 @@ Before diving into all of the options available to you when writing resources, l
 
 Every resource class defines a `toArray` method which returns the array of attributes that should be converted to JSON when sending the response. Notice that we can access model properties directly from the `$this` variable. This is because a resource class will automatically proxy property and method access down to the underlying model for convenient access. Once the resource is defined, it may be returned from a route or controller:
 
+모든 리소스 클래스는 응답-response를 내보낼 때 JSON으로 변환되어야 하는 속성 배열을 반환하는 `toArray` 메소드를 정의하고 있습니다. `$this` 변수를 통해서 모델에 직접 엑세스 할 수 있습니다. 이는 리소스 클래스가 자동으로 기본 모델에 대한 속성과 메소드에 엑세스 할 수 있게 프록시를 제공하기 때문입니다. 리소스 클래스를 정의하면, 이는 라우트 또는 컨트롤러에서 반환 할 수 있게됩니다:
+
     use App\User;
     use App\Http\Resources\UserResource;
 
@@ -76,8 +105,11 @@ Every resource class defines a `toArray` method which returns the array of attri
     });
 
 ### Resource Collections
+### 리소스 컬렉션
 
 If you are returning a collection of resources or a paginated response, you may use the `collection` method when creating the resource instance in your route or controller:
+
+리소스 컬렉션이나, 페이지네이션 처리된 응답을 반환하는 경우, 라우트나 컨트롤러에서 리소스 인스턴스를 생성하기 위해서 `collection` 메소드를 사용할 수 있습니다:
 
     use App\User;
     use App\Http\Resources\UserResource;
@@ -88,9 +120,13 @@ If you are returning a collection of resources or a paginated response, you may 
 
 Of course, this does not allow any addition of meta data that may need to be returned with the collection. If you would like to customize the resource collection response, you may create a dedicated resource to represent the collection:
 
+이 경우에는 컬렉션과 함께 리턴하고자 하는 메타 데이터는 추가할 수 없습니다. 리소스 컬렉션 응답-response를 커스터마이징 하고자 하는 경우에는, 컬렉션을 나타내는 특정한 리소스 클래스를 생성할 수 있습니다:
+
     php artisan make:resource UserCollection
 
 Once the resource collection class has been generated, you may easily define any meta data that should be included with the response:
+
+리소스 컬렉션 클래스를 생성하면, 응답-response에 포함되어야할 메타 데이터를 손쉽게 정의할 수 있습니다:
 
     <?php
 
@@ -119,6 +155,8 @@ Once the resource collection class has been generated, you may easily define any
 
 After defining your resource collection, it may be returned from a route or controller:
 
+리소스 컬렉션 클래스를 정의하고 나면, 라우트나 컨트롤러에서 이를 반환할 수 있습니다:
+
     use App\User;
     use App\Http\Resources\UserCollection;
 
@@ -128,10 +166,15 @@ After defining your resource collection, it may be returned from a route or cont
 
 <a name="writing-resources"></a>
 ## Writing Resources
+## 리소스 클래스 작성하기
 
 > {tip} If you have not read the [concept overview](#concept-overview), you are highly encouraged to do so before proceeding with this documentation.
 
+> {tip} [컨셉 살펴보기](#concept-overview)를 읽지 않았다면, 아래 문서를 확인하기 전에 해당 부분을 먼저 읽어보시기 바랍니다.
+
 In essence, resources are simple. They only need to transform a given model into an array. So, each resource contains a `toArray` method which translates your model's attributes into an API friendly array that can be returned to your users:
+
+본질적으로, 리소스라는 것은 간단합니다. 리소스의 역할은 모델을 배열로 반환하는 하는 것입니다. 따라서 각 리소스 클래스에는 모델의 속성을 사용자에게 반환할 수 있도록 API 친화적인 배열로 변환하는 `toArray` 메소드를 포함하게 됩니다:
 
     <?php
 
@@ -161,6 +204,8 @@ In essence, resources are simple. They only need to transform a given model into
 
 Once a resource has been defined, it may be returned directly from a route or controller:
 
+리소스 클래스를 정의하고 나면, 라우트나 컨트롤러에서 바로 반환할 수 있습니다:
+
     use App\User;
     use App\Http\Resources\UserResource;
 
@@ -169,8 +214,11 @@ Once a resource has been defined, it may be returned directly from a route or co
     });
 
 #### Relationships
+#### 관계-relationships
 
 If you would like to include related resources in your response, you may add them to the array returned by your `toArray` method. In this example, we will use the `Post` resource's `collection` method to add the user's blog posts to the resource response:
+
+응답-response에서 연관된 리소스(relationships)를 포함하고자 한다면, `toArray` 메소드에서 반환하는 배열에 이를 추가하면 됩니다. 다음 예제에서는 `Post` 리소스의 `collection` 메소드를 사용하여 사용자의 블로그 포스트를 응답-response에 추가합니다:
 
     /**
      * Transform the resource into an array.
@@ -192,9 +240,14 @@ If you would like to include related resources in your response, you may add the
 
 > {tip} If you would like to include relationships only when they have already been loaded, check out the documentation on [conditional relationships](#conditional-relationships).
 
+> {tip} 이미 로딩된 경우에만, 관계-relationships을 포함하고자 한다면, [조건에 따른 관계 표현](#conditional-relationships) 문서를 확인하십시오.
+
 #### Resource Collections
+#### 리소스 컬렉션
 
 While resources translate a single model into an array, resource collections translate a collection of models into an array. It is not absolutely necessary to define a resource collection class for each one of your model types since all resources provide a `collection` method to generate an "ad-hoc" resource collection on the fly:
+
+리소스가 하나의 모델을 배열로 변환한다면, 리소스 컬렉션은 모델 컬렉션을 배열로 변환합니다. 모든 리소스 클래스는 "ad-hoc"을 생성하는 `collection` 메소드를 제공하고 있기 때문에, 모든 모델에 대해서 리소스 컬렉션 클래스를 정의할 필요는 없습니다:
 
     use App\User;
     use App\Http\Resources\UserResource;
@@ -204,6 +257,8 @@ While resources translate a single model into an array, resource collections tra
     });
 
 However, if you need to customize the meta data returned with the collection, it will be necessary to define a resource collection:
+
+그렇지만, 컬렉션에서 메타데이터를 포함하는 것과 같이 커스터마이징이 필요하다면, 리소스 컬렉션 클래스를 정의해야 합니다:
 
     <?php
 
@@ -232,6 +287,8 @@ However, if you need to customize the meta data returned with the collection, it
 
 Like singular resources, resource collections may be returned directly from routes or controllers:
 
+단일 리소스와 같이, 리소스 컬렉션은 라우트나 컨트롤러에서 바로 반환할 수 있습니다:
+
     use App\User;
     use App\Http\Resources\UserCollection;
 
@@ -241,8 +298,11 @@ Like singular resources, resource collections may be returned directly from rout
 
 <a name="data-wrapping"></a>
 ### Data Wrapping
+### 데이터 Wrapping(랩핑)
 
 By default, your outer-most resource is wrapped in a `data` key when the resource response is converted to JSON. So, for example, a typical resource collection response looks like the following:
+
+기본적으로, 리소스를 통한 응답-response는 JSON으로 변환될 때 "data"라는 키로 랩핑됩니다. 예들 들자면, 일반적인 리소스 응답-response는 다음과 같습니다:
 
     {
         "data": [
@@ -260,6 +320,8 @@ By default, your outer-most resource is wrapped in a `data` key when the resourc
     }
 
 If you would like to disable the wrapping of the outer-most resource, you may use the `withoutWrapping` method on the base resource class. Typically, you should call this method from your `AppServiceProvider` or another [service provider](/docs/{{version}}/providers) that is loaded on every request to your application:
+
+위와 같은 데이터 랩핑을 원하지 않는다면, base 리소스 클래스에 `withoutWrapping` 메소드를 사용하면 됩니다. 일반적으로 이 메소드는 `AppServiceProvider` 또는 어플리케이션의 다른 서비스 프로바이더에서 호출해야 합니다:
 
     <?php
 
@@ -293,11 +355,18 @@ If you would like to disable the wrapping of the outer-most resource, you may us
 
 > {note} The `withoutWrapping` method only affects the outer-most response and will not remove `data` keys that you manually add to your own resource collections.
 
+> {note} `withoutWrapping` 메소드는 가장 바깥쪽의 데이터 구조에만 영향을 주며, `data` 키를 제거하지는 않습니다.
+
 ### Wrapping Nested Resources
+### 중첩된 리소스 랩핑
 
 You have total freedom to determine how your resource's relationships are wrapped. If you would like all resource collections to be wrapped in a `data` key, regardless of their nesting, you should define a resource collection class for each resource and return the collection within a `data` key.
 
+리소스에서 관계-relationships이 어떻게 랩핑될지 자유롭게 결정할 수 있습니다. 중첩(nested)되었는지에 상관없이 모든 리소스 컬렉션을 `data` 키에 랩핑하고자 한다면, 각 리소스에 대한 리소스 컬렉션 클래스를 정의하고 `data` 키 안에서 컬렉션을 반환해야 합니다.
+
 Of course, you may be wondering if this will cause your outer-most resource to be wrapped in two `data` keys. Don't worry, Laravel will never let your resources be accidentally double-wrapped, so you don't have to be concerned about the nesting level of the resource collection you are transforming:
+
+이렇게 되었을 때, 외부 리소스가 두개의 `data` 키로 랩핑되어 있는지 의문을 가질 수 있습니다. 걱정하지 마십시오. 라라벨은 리소스를 두번 랩핑하지 않으므로 변환중인 리소스 컬렉션이 중첩되었는지에 대해서 걱정할 필요가 없습니다:
 
     <?php
 
@@ -320,8 +389,11 @@ Of course, you may be wondering if this will cause your outer-most resource to b
     }
 
 ### Data Wrapping And Pagination
+### 데이터 랩핑과 페이지네이션
 
 When returning paginated collections in a resource response, Laravel will wrap your resource data in a `data` key even if the `withoutWrapping` method has been called. This is because paginated responses always contain `meta` and `links` keys with information about the paginator's state:
+
+리소스 응답-response에서 페이징된 컬렉션을 반환할 때, 라라벨은 `withoutWrapping` 메소드가 호출 된 경우에도 리소스 데이터를 `data` 키로 랩핑합니다. 이는 페이징된 응답-response는 항상 페이지네이터의 상태를 나타내는 `meta`, `links` 키가 포함되기 때문입니다:
 
     {
         "data": [
@@ -355,8 +427,11 @@ When returning paginated collections in a resource response, Laravel will wrap y
 
 <a name="pagination"></a>
 ### Pagination
+### 페이지네이션
 
 You may always pass a paginator instance to the `collection` method of a resource or to a custom resource collection:
+
+커스텀 리소스 컬렉션이나 리소스의 `collection` 메소드에 페이지네이터의 인스턴스를 전달할 수 있습니다:
 
     use App\User;
     use App\Http\Resources\UserCollection;
@@ -366,6 +441,8 @@ You may always pass a paginator instance to the `collection` method of a resourc
     });
 
 Paginated responses always contain `meta` and `links` keys with information about the paginator's state:
+
+페이징된 응답-response는 항상 페이지네이터의 상태를 나타내는 `meta`, `links` 키가 포함됩니다:
 
     {
         "data": [
@@ -399,8 +476,11 @@ Paginated responses always contain `meta` and `links` keys with information abou
 
 <a name="conditional-attributes"></a>
 ### Conditional Attributes
+### 조건에 따른 속성값 표현
 
 Sometimes you may wish to only include an attribute in a resource response if a given condition is met. For example, you may wish to only include a value if the current user is an "administrator". Laravel provides a variety of helper methods to assist you in this situation. The `when` method may be used to conditionally add an attribute to a resource response:
+
+때로는 주어진 조건이 충족 될 때, 리소스 응답에 지정된 속성을 포함시키고자 할 수도 있습니다. 예를 들어 현재 사용자가 "관리자-administrator"인 경우에만 값을 포함하고자 할 수 있습니다. 라라벨은 이러한 경우를 지원하기 위해서 다양한 헬퍼 메소드를 제공합니다. `when` 메소드는 리소스 응답-response에 조건에 따라 속성을 추가하는데 사용됩니다:
 
     /**
      * Transform the resource into an array.
@@ -422,7 +502,11 @@ Sometimes you may wish to only include an attribute in a resource response if a 
 
 In this example, the `secret` key will only be returned in the final resource response if the `$this->isAdmin()` method returns `true`. If the method returns `false`, the `secret` key will be removed from the resource response entirely before it is sent back to the client. The `when` method allows you to expressively define your resources without resorting to conditional statements when building the array.
 
+이 예제에서 `$this->isAdmin()` 메소드가 `true`를 반환 하면 최종적인 리소스 응답-response에 `scret` 키가 반환됩니다. 이 메소드가 `false`를 반환하면, `secret` 키는 리소스 응답-response이 클라이언트에게 보내기 전에 제거됩니다. `when` 메소드를 사용하면, 배열을 만들 때 조건문을 사용하지 않고 명시적으로 리소스를 정의할 수 있습니다.
+
 The `when` method also accepts a Closure as its second argument, allowing you to calculate the resulting value only if the given condition is `true`:
+
+`when` 메소드는 두번째 인자로 클로저를 받을 수 있는데, 주어진 조건이 `true` 인 경우에 결과 값을 계산합니다:
 
     'secret' => $this->when($this->isAdmin(), function () {
         return 'secret-value';
@@ -430,9 +514,14 @@ The `when` method also accepts a Closure as its second argument, allowing you to
 
 > {tip} Remember, method calls on resources proxy down to the underlying model instance. So, in this case, the `isAdmin` method is proxying to the underlying Eloquent model that was originally given to the resource.
 
+> {팁} 유의할 것은, 리소스 프록시에서의 메소드 호출은 기본 모델 인스턴스까지 전달된다는 점입니다. 따라서 이 경우 `isAdmin` 메소드는 원래 리소스에 제공되는 기본 Eloquent 모델의 메소드로 프록시 전달됩니다.
+
 #### Merging Conditional Attributes
+#### 조건에 따라 속성값 포함시키기
 
 Sometimes you may have several attributes that should only be included in the resource response based on the same condition. In this case, you may use the `mergeWhen` method to include the attributes in the response only when the given condition is `true`:
+
+때로는 특정 조건에 기반헤서 리소스 응답-response에 포함되어야 할 속성을 구성할 수도 있습니다. 이 경우 `mergeWhen` 메소드를 사용하여 주어진 조건이 `true` 일 때만 응답-response에 속성값을 포함시킬 수 있습니다:
 
     /**
      * Transform the resource into an array.
@@ -457,14 +546,23 @@ Sometimes you may have several attributes that should only be included in the re
 
 Again, if the given condition is `false`, these attributes will be removed from the resource response entirely before it is sent to the client.
 
+주어진 조건이 `false` 인 경우에는 리소스 응답-response이 클라이언트에게 보내기 전에 제거됩니다.
+
 > {note} The `mergeWhen` method should not be used within arrays that mix string and numeric keys. Furthermore, it should not be used within arrays with numeric keys that are not ordered sequentially.
+
+> {note} `mergeWhen` 메소드는 문자열과 숫자 키가 섞여 있는 배열 안에서 사용하면 안됩니다. 그리고 순서대로 정렬되지 않은 숫자 키가 있는 배열에서도 마찬가지로 사용하면 안됩니다.
 
 <a name="conditional-relationships"></a>
 ### Conditional Relationships
+### 조건에 따라 관계-relationship 표시하기
 
 In addition to conditionally loading attributes, you may conditionally include relationships on your resource responses based on if the relationship has already been loaded on the model. This allows your controller to decide which relationships should be loaded on the model and your resource can easily include them only when they have actually been loaded.
 
+조건에 따라서 속성값을 표시하는 것에 더해서, 모델에 관계-relationship 이 로딩되어 있는 경우에 조건에 따라서, 응답-response에 관계-relationship을 포함 시킬 수 있습니다. 컨트롤러는 이를 통해서 어떤 관계-relationship을 로딩해야 하는지 결정할 수 있으며 실제로 로딩된 경우에만 리소스에 쉽게 포함 시킬 수 있습니다.
+
 Ultimately, this makes it easier to avoid "N+1" query problems within your resources. The `whenLoaded` method may be used to conditionally load a relationship. In order to avoid unnecessarily loading relationships, this method accepts the name of the relationship instead of the relationship itself:
+
+궁극적으로 이는 리소스 안에서 "N+1" 쿼리 문제를 회피할 수 있도록 해줍니다. `whenLoaded` 메소드는 조건에 따라 관계-relationship 를 로딩하는데 사용할 수 있습니다. 필요하지 않은 관계-relationship를 로딩하는 것을 회피하기 위해서 이 메소드는 관계-relationship 그 자체 대신 관계-relationship 이름을 인지로 받습니다:
 
     /**
      * Transform the resource into an array.
@@ -486,9 +584,14 @@ Ultimately, this makes it easier to avoid "N+1" query problems within your resou
 
 In this example, if the relationship has not been loaded, the `posts` key will be removed from the resource response entirely before it is sent to the client.
 
+이 예제에서 관계-relationship가 로딩되지 않은 경우에 리소스 응답-response에서 `posts` 키는 제거됩니다.
+
 #### Conditional Pivot Information
+#### 조건에 따른 피벗 정보 포함하기
 
 In addition to conditionally including relationship information in your resource responses, you may conditionally include data from the intermediate tables of many-to-many relationships using the `whenPivotLoaded` method. The `whenPivotLoaded` method accepts the name of the pivot table as its first argument. The second argument should be a Closure that defines the value to be returned if the pivot information is available on the model:
+
+리소스 응답-response에서 조건에 따라 관계-relationship를 포함하는 것에 더해서, `whenPivotLoaded` 메소드를 사용해서 다대다 관계-relationship 에서 조건에 따라서 중간 테이블을 포함시킬 수 있습니다. `whenPivotLoaded` 메소드는 첫번째 인자로 피벗 테이블의 이름을 전달 받고, 두번째 인자로 모델에서 피벗 정보를 사용할 수 있는 경우 반환 할 값을 정의하는 클로저를 전달받습니다:
 
     /**
      * Transform the resource into an array.
@@ -509,8 +612,11 @@ In addition to conditionally including relationship information in your resource
 
 <a name="adding-meta-data"></a>
 ### Adding Meta Data
+### 메타 데이터 추가하기
 
 Some JSON API standards require the addition of meta data to your resource and resource collections responses. This often includes things like `links` to the resource or related resources, or meta data about the resource itself. If you need to return additional meta data about a resource, include it in your `toArray` method. For example, you might include `link` information when transforming a resource collection:
+
+일부 JSON API 표준에서는 리소스 및 리소스 컬렉션 응답-response에 메타 데이터를 추가해야합니다. 여기에는 리소스 또는 연관된 리소스에 `links` 같은 데이터를 추가하거나, 리소스 그 자체에 대한 메타 데이터를 추가하는 것들이 포함됩니다. 만약 여러분이 리소스에 대한 추가적인 메타 데이터를 반환할 필요가 있다면, 간단하게 `toArray` 메소드를 포함시키면 됩니다. 예를 들어, 다음처럼 리소스 컬렉션이 변환될 때 `link` 정보를 포함시킬 수 있습니다:
 
     /**
      * Transform the resource into an array.
@@ -530,9 +636,14 @@ Some JSON API standards require the addition of meta data to your resource and r
 
 When returning additional meta data from your resources, you never have to worry about accidentally overriding the `links` or `meta` keys that are automatically added by Laravel when returning paginated responses. Any additional `links` you define will be merged with the links provided by the paginator.
 
+리소스에서 추가적인 메타 데이터를 반환 할 때는, 페이징 처리된 응답-reponse가 반환 하면서 실수로 라라벨에 의해서 자동으로 추가되는 `links` 또는 `mata` 키를 오버라이딩 하는 것을 걱정하지 않아도 됩니다. 여러분이 정의한 추가적인 `links`는 페이지네이터에 의해서 제공되는 링크와 자동으로 병합됩니다.
+
 #### Top Level Meta Data
+#### 최상위 레벨의 메타 데이터
 
 Sometimes you may wish to only include certain meta data with a resource response if the resource is the outer-most resource being returned. Typically, this includes meta information about the response as a whole. To define this meta data, add a `with` method to your resource class. This method should return an array of meta data to be included with the resource response only when the resource is the outer-most resource being rendered:
+
+반환되는 리소스가 가장 외부의 리소스인 경우에, 리소스 응답-response에 특정 메타 데이터만을 포함시키기를 원할 수 있습니다. 일반적으로 이는 전체적인 응답-response에 대한 메타데이터를 포함합니다. 이러한 메타 데이터를 정의하려면, 리소스 클래스에 `with` 메소드를 추가하면 됩니다. 이 메소드는 리소스가 렌더링 되는 가장 외부의 리소스인 경우에 리소스 응답에 포함되어야 하는 메타 데이터의 배열을 반환해야 합니다:
 
     <?php
 
@@ -570,8 +681,11 @@ Sometimes you may wish to only include certain meta data with a resource respons
     }
 
 #### Adding Meta Data When Constructing Resources
+#### 리소스가 생성될 때 메타 데이터 추가하기
 
 You may also add top-level data when constructing resource instances in your route or controller. The `additional` method, which is available on all resources, accepts an array of data that should be added to the resource response:
+
+또한 라우트 또는 컨트롤러에서 리소스 인스턴스가 생성될 때, 최상위 레벨의 데이터를 추가할 수도 있습니다. 모든 리소스에서 사용될 수 있는 `additional` 메소드는 리소스 응답-response에서 추가되야 하는 데이터의 베열을 인자로 받습니다:
 
     return (new UserCollection(User::all()->load('roles')))
                     ->additional(['meta' => [
@@ -580,8 +694,11 @@ You may also add top-level data when constructing resource instances in your rou
 
 <a name="resource-responses"></a>
 ## Resource Responses
+## 리소스 응답-Responses
 
 As you have already read, resources may be returned directly from routes and controllers:
+
+앞서 확인한 것 처럼, 리소스는 라우트나 컨트롤러에서 바로 반환할 수 있습니다:
 
     use App\User;
     use App\Http\Resources\UserResource;
@@ -591,6 +708,8 @@ As you have already read, resources may be returned directly from routes and con
     });
 
 However, sometimes you may need to customize the outgoing HTTP response before it is sent to the client. There are two ways to accomplish this. First, you may chain the `response` method onto the resource. This method will return an `Illuminate\Http\Response` instance, allowing you full control of the response's headers:
+
+그렇지만, 때때로 클라이언트에 HTTP 응답-response를 내보내기 전에 이를 커스터마이징 해야 할 때도 있습니다. 이 경우, 두가지 방법이 있는데, 먼저 리소스에 `response` 메소드를 체이닝 형태로 사용하면 됩니다. 이 메소드는 `Illuminate\Http\Response` 인스턴스를 반환하는데, 이를 사용하여 응답-response의 헤더를 조작할 수 있습니다:
 
     use App\User;
     use App\Http\Resources\UserResource;
@@ -602,6 +721,8 @@ However, sometimes you may need to customize the outgoing HTTP response before i
     });
 
 Alternatively, you may define a `withResponse` method within the resource itself. This method will be called when the resource is returned as the outer-most resource in a response:
+
+다른 방법으로는, 리소스 클래스에 `withResponse` 메소드를 정의하면 됩니다. 이 메소드는 리소스가 반환될 때, 호출됩니다:
 
     <?php
 

--- a/kr/eloquent-serialization.md
+++ b/kr/eloquent-serialization.md
@@ -1,25 +1,40 @@
 # Eloquent: Serialization
+# Eloquent: Serialization
 
 - [Introduction](#introduction)
+- [소개하기](#introduction)
 - [Serializing Models & Collections](#serializing-models-and-collections)
+- [모델 & 컬렉션 Serializing](#serializing-models-and-collections)
     - [Serializing To Arrays](#serializing-to-arrays)
+    - [배열로 Serializing](#serializing-to-arrays)
     - [Serializing To JSON](#serializing-to-json)
+    - [JSON 으로 Serializing](#serializing-to-json)
 - [Hiding Attributes From JSON](#hiding-attributes-from-json)
+- [JSON 변환시 속성값 숨시기](#hiding-attributes-from-json)
 - [Appending Values To JSON](#appending-values-to-json)
+- [JSON 변환시 특정 값 추가하기](#appending-values-to-json)
 - [Date Serialization](#date-serialization)
+- [날짜 Serialization](#date-serialization)
 
 <a name="introduction"></a>
 ## Introduction
+## 소개하기
 
 When building JSON APIs, you will often need to convert your models and relationships to arrays or JSON. Eloquent includes convenient methods for making these conversions, as well as controlling which attributes are included in your serializations.
 
+JSON API를 구성할 때, 여러분은 자주 특정 모델과, 연관된 모델들을 배열 또는 JSON 으로 변환해야될 필요가 있을 것입니다. Eloquent 는 serialization 에서 이러한 변환들과, 어떠한 속성들이 JSON에 포함되어야 하는지 제어할 수 있도록 편리한 메소드들을 가지고 있습니다.
+
 <a name="serializing-models-and-collections"></a>
 ## Serializing Models & Collections
+## 모델 & 컬렉션 Serializing
 
 <a name="serializing-to-arrays"></a>
 ### Serializing To Arrays
+### 배열로 Serializaing
 
 To convert a model and its loaded [relationships](/docs/{{version}}/eloquent-relationships) to an array, you should use the `toArray` method. This method is recursive, so all attributes and all relations (including the relations of relations) will be converted to arrays:
+
+하나의 모델과 연관된 [관계 모델](/docs/{{version}}/eloquent-relationships)들을 배열로 변환 하고자 할 때에는, `toArray` 메소드를 사용해야만 합니다. 이 메소드는 재귀적이기 때문에, 모든 속성들과 모든 관계 모델들(관계 모델들 안에 포함된 관계 모델들까지)이 배열로 변환될 것입니다.
 
     $user = App\User::with('roles')->first();
 
@@ -27,14 +42,19 @@ To convert a model and its loaded [relationships](/docs/{{version}}/eloquent-rel
 
 You may also convert entire [collections](/docs/{{version}}/eloquent-collections) of models to arrays:
 
+또한 전체 모델 [collections](/docs/{{version}}/eloquent-collections)을 배열로 변환할 수도 있습니다. 
+
     $users = App\User::all();
 
     return $users->toArray();
 
 <a name="serializing-to-json"></a>
 ### Serializing To JSON
+### JSON으로 Serializaing
 
 To convert a model to JSON, you should use the `toJson` method. Like `toArray`, the `toJson` method is recursive, so all attributes and relations will be converted to JSON:
+
+모델을 JSON으로 변환하기 위해서는, `toJson` 메소드를 사용해야 합니다. `toArray` 와 같이 `toJson` 메소드는 재귀적이므로, 모든 속성과 관계 모델들은 JSON으로 변환될 것입니다:
 
     $user = App\User::find(1);
 
@@ -42,11 +62,15 @@ To convert a model to JSON, you should use the `toJson` method. Like `toArray`, 
 
 Alternatively, you may cast a model or collection to a string, which will automatically call the `toJson` method on the model or collection:
 
+이렇게 하는 대신에, 모델 또는 컬렉션을 문자열(string)으로 캐스팅하면, 자동으로 `toJson` 메소드가 호출 될것입니다.
+
     $user = App\User::find(1);
 
     return (string) $user;
 
 Since models and collections are converted to JSON when cast to a string, you can return Eloquent objects directly from your application's routes or controllers:
+
+모델과 컬렉션을 문자열로 캐스팅할 때에는, JSON으로 변환되므로, 어플리케이션의 라우트 또는 컨트롤러에서 Eloquent 객체를 바로 반환할 수도 있습니다. 
 
     Route::get('users', function () {
         return App\User::all();
@@ -54,8 +78,11 @@ Since models and collections are converted to JSON when cast to a string, you ca
 
 <a name="hiding-attributes-from-json"></a>
 ## Hiding Attributes From JSON
+## JSON 변환시 속성값 숨시기
 
 Sometimes you may wish to limit the attributes, such as passwords, that are included in your model's array or JSON representation. To do so, add a `$hidden` property to your model:
+
+때로는 패스워드와 같이, 모델이 배열 또는 JSON으로 재구성될 때 속성을 제한하고자 할 수도 있습니다. 이렇게 하기 위해서는 모델의 `$hidden` 속성에 제한하고자 하는 필드를 추가하면 됩니다.
 
     <?php
 
@@ -75,7 +102,11 @@ Sometimes you may wish to limit the attributes, such as passwords, that are incl
 
 > {note} When hiding relationships, use the relationship's method name.
 
+> {note} 관계를 숨기고자 할 때에는, 관계에 대한 메소드 이름을 사용하십시오
+
 Alternatively, you may use the `visible` property to define a white-list of attributes that should be included in your model's array and JSON representation. All other attributes will be hidden when the model is converted to an array or JSON:
+
+이렇게 하는 대신, 모델이 배열 또는 JSON으로 재구성될 때 포함되어야 하는 속성들에 대한 화이트 리스트를 정의하는 `visible` 값을 사용할 수도 있습니다. 모든 다른 속성들은 모델이 배열이나 JSON 으로 변환될 때 숨겨질 것입니다.
 
     <?php
 
@@ -94,19 +125,27 @@ Alternatively, you may use the `visible` property to define a white-list of attr
     }
 
 #### Temporarily Modifying Attribute Visibility
+#### 일시적으로 속성들의 노출 정도를 수정하기 
 
 If you would like to make some typically hidden attributes visible on a given model instance, you may use the `makeVisible` method. The `makeVisible` method returns the model instance for convenient method chaining:
+
+주어진 모델 인스턴스에서 몇가지 일반적인 숨겨진 속성을 보이도록 만들고자 한다면, `makeVisible` 메소드를 사용하면 됩니다. `makeVisible` 메소드는 편리한 메소드 체이닝을 위해서 모델 인스턴스를 반환합니다:
 
     return $user->makeVisible('attribute')->toArray();
 
 Likewise, if you would like to make some typically visible attributes hidden on a given model instance, you may use the `makeHidden` method.
 
+마찬가지로, 주어진 모델 인스턴스에서 몇가지 일반적으로 보여지던 속성을 보이지 않도록 만들고자 한다면, `makeHidden`메소드를 사용하면 됩니다.
+
     return $user->makeHidden('attribute')->toArray();
 
 <a name="appending-values-to-json"></a>
 ## Appending Values To JSON
+## JSON 변환시 특정 값 추가하기
 
 Occasionally, when casting models to an array or JSON, you may wish to add attributes that do not have a corresponding column in your database. To do so, first define an [accessor](/docs/{{version}}/eloquent-mutators) for the value:
+
+때때로, 모델이 배열이나 JSON으로 캐스팅 될 때, 데이터베이스의 컬럼에 일치하지 않는 속성들을 추가하기를 원할 수도 있습니다. 이렇게 하기 위해서는, 단순히 값에 대한 [accessor](/docs/{{version}}/eloquent-mutators)를 정의하면 됩니다:
 
     <?php
 
@@ -129,6 +168,8 @@ Occasionally, when casting models to an array or JSON, you may wish to add attri
 
 After creating the accessor, add the attribute name to the `appends` property on the model. Note that attribute names are typically referenced in "snake case", even though the accessor is defined using "camel case":
 
+accessor 를 생성한 다음에, 모델의 `appends`값에 속성의 이름을 추가합니다. accessor 가 "카멜 케이스"로 정의되어 있더라도, 속성 이름은 정상적으로 "스네이크 케이스"로 엑세스 됩니다: 
+
     <?php
 
     namespace App;
@@ -147,9 +188,14 @@ After creating the accessor, add the attribute name to the `appends` property on
 
 Once the attribute has been added to the `appends` list, it will be included in both the model's array and JSON representations. Attributes in the `appends` array will also respect the `visible` and `hidden` settings configured on the model.
 
+속성이 `appends` 리스트에 추가되고나면 모델이 배열이나 JSON 형태로 변환될 때 자동으로 포함될 것입니다 .`appends` 배열 안에 있는 속성들은 또한 모델에 정의된 `visible`와 `hidden`값에 영향을 받을 것입니다.
+
 #### Appending At Run Time
+#### 실행 될때(run time에서) 추가하기
 
 You may instruct a single model instance to append attributes using the `append` method. Or, you may use the `setAppends` method to override the entire array of appended properties for a given model instance:
+
+`append` 메소드를 사용해서 하나의 모델 인스턴스에 속성을 추가할 수도 있습니다. 또는 `setAppends` 메소드를 사용하여 주어진 모델 인스턴스에 추가된 속성들의 전체 배열을 오버라이드 할 수 있습니다:
 
     return $user->append('is_admin')->toArray();
 
@@ -158,9 +204,15 @@ You may instruct a single model instance to append attributes using the `append`
 <a name="date-serialization"></a>
 ## Date Serialization
 
+## 날짜 Serialization
+
 #### Customizing The Date Format Per Attribute
 
+#### 날짜 포맷의 속성을 커스터마이징 하기
+
 You may customize the serialization format of individual Eloquent date attributes by specifying the date format in the [cast declaration](/docs/{{version}}/eloquent-mutators#attribute-casting):
+
+만약 각각의 Eloquent 시리얼라이즈 포맷을 커스터마이즈 하고싶다면, 날짜 형식은 [cast declaration](/docs/{{version}}/eloquent-mutators#attribute-casting) 에 자세하게 명시되어 있습니다:
 
     protected $casts = [
         'birthday' => 'date:Y-m-d',
@@ -169,7 +221,11 @@ You may customize the serialization format of individual Eloquent date attribute
 
 #### Global Customization Via Carbon
 
+#### Carbon을 통한 전역 커스터마이징
+
 Laravel extends the [Carbon](https://github.com/briannesbitt/Carbon) date library in order to provide convenient customization of Carbon's JSON serialization format. To customize how all Carbon dates throughout your application are serialized, use the `Carbon::serializeUsing` method. The `serializeUsing` method accepts a Closure which returns a string representation of the date for JSON serialization:
+
+라라벨은 Carbon의 JSON 시리얼라이즈 포맷을 편리하게 정의할 수 있도록 [Carbon](https://github.com/briannesbitt/Carbon) 날짜 라이브러리를 확장하고 있습니다. 어플리케이션에서 시리얼라이즈 되는 모든 Carbon 날짜를 커스터마이징 하려면 `Carbon::serializeUsing` 메소드를 사용하면 됩니다. `Carbon::serializeUsing` 메소드는 JSON 시리얼라이즈되는 날짜의 문자형식을 반환하는 클로저를 인자로 받습니다:
 
     <?php
 

--- a/kr/eloquent.md
+++ b/kr/eloquent.md
@@ -1,44 +1,78 @@
 # Eloquent: Getting Started
+# Eloquent: 시작하기
 
 - [Introduction](#introduction)
+- [소개](#introduction)
 - [Defining Models](#defining-models)
+- [모델 정의하기](#defining-models)
     - [Eloquent Model Conventions](#eloquent-model-conventions)
+    - [Eloquent 모델 컨벤션](#eloquent-model-conventions)
 - [Retrieving Models](#retrieving-models)
+- [모델 조회하기](#retrieving-models)
     - [Collections](#collections)
+    - [컬렉션](#collections)
     - [Chunking Results](#chunking-results)
+    - [결과 분할하기](#chunking-results)
 - [Retrieving Single Models / Aggregates](#retrieving-single-models)
+- [하나의 모델 / 합계를 찾기](#retrieving-single-models)
     - [Retrieving Aggregates](#retrieving-aggregates)
+    - [합계 가져오기](#retrieving-aggregates)
 - [Inserting & Updating Models](#inserting-and-updating-models)
+- [모델을 통한 추가 및 삭제하기](#inserting-and-updating-models)
+    - [Inserts](#inserts)
     - [Inserts](#inserts)
     - [Updates](#updates)
+    - [Updates](#updates)
     - [Mass Assignment](#mass-assignment)
+    - [대량 할당 - Mass Assignment](#mass-assignment)
     - [Other Creation Methods](#other-creation-methods)
+    - [기타 생성을 위한 메소드들](#other-creation-methods)
 - [Deleting Models](#deleting-models)
+- [모델 삭제하기](#deleting-models)
     - [Soft Deleting](#soft-deleting)
+    - [소프트 삭제하기](#soft-deleting)
     - [Querying Soft Deleted Models](#querying-soft-deleted-models)
+    - [소프트 삭제된 모델 쿼리하기](#querying-soft-deleted-models)
 - [Query Scopes](#query-scopes)
+- [쿼리 스코프](#query-scopes)
     - [Global Scopes](#global-scopes)
+    - [글로벌 스코프](#global-scopes)
     - [Local Scopes](#local-scopes)
+    - [로컬 스코프](#local-scopes)
 - [Events](#events)
+- [이벤트](#events)
     - [Observers](#observers)
+    - [옵저버](#observers)
 
 <a name="introduction"></a>
 ## Introduction
+## 소개하기
 
 The Eloquent ORM included with Laravel provides a beautiful, simple ActiveRecord implementation for working with your database. Each database table has a corresponding "Model" which is used to interact with that table. Models allow you to query for data in your tables, as well as insert new records into the table.
 
+라라벨에 포함된 Eloquent ORM은 여러분의 데이터베이스에서 동작하는 아름답고 심플한 액티브 레코드를 제공합니다. 각각의 데이터베이스 테이블은 이에 해당하는 "모델"을 가지고 있습니다.
+
 Before getting started, be sure to configure a database connection in `config/database.php`. For more information on configuring your database, check out [the documentation](/docs/{{version}}/database#configuration).
+
+시작하기에 앞서 `config/database.php` 에 데이터베이스 커넥션이 설정되어 있는지 확인하십시오.
 
 <a name="defining-models"></a>
 ## Defining Models
+## 모델 정의하기
 
 To get started, let's create an Eloquent model. Models typically live in the `app` directory, but you are free to place them anywhere that can be auto-loaded according to your `composer.json` file. All Eloquent models extend `Illuminate\Database\Eloquent\Model` class.
 
+시작하기 위해서 Eloquent 모델 하나를 생성합니다. 일반적으로 모델은 `app` 디렉토리에 존재하지만, `composer.json` 파일에 의해서 오토로드 되는 곳이라면 어느곳에든 위치해도 상관없습니다. 모든 Eloquent 모델은 `Illuminate\Database\Eloquent\Model`을 상속받습니다.
+
 The easiest way to create a model instance is using the `make:model` [Artisan command](/docs/{{version}}/artisan):
+
+모델 인스턴스를 생성하는 가장 쉬운 방법은 `make:model` [아티즌 커맨드](/docs/{{version}}/artisan)를 사용하는 것입니다:
 
     php artisan make:model User
 
 If you would like to generate a [database migration](/docs/{{version}}/migrations) when you generate the model, you may use the `--migration` or `-m` option:
+
+모델을 생성할 때 [데이터 마이그레이션](/docs/{{version}}/migrations)을 생성하고 싶다면 `--migration` 혹은 `-m` 옵션을 사용할 수 있습니다:
 
     php artisan make:model User --migration
 
@@ -46,8 +80,11 @@ If you would like to generate a [database migration](/docs/{{version}}/migration
 
 <a name="eloquent-model-conventions"></a>
 ### Eloquent Model Conventions
+### Eloquent 모델 컨벤션
 
 Now, let's look at an example `Flight` model, which we will use to retrieve and store information from our `flights` database table:
+
+이제 `flights` 데이터베이스 테이블에서 정보를 찾거나 저장할 때 쓸 `Flight` 모델의 예를 보겠습니다:
 
     <?php
 
@@ -61,8 +98,11 @@ Now, let's look at an example `Flight` model, which we will use to retrieve and 
     }
 
 #### Table Names
+#### 테이블 이름
 
 Note that we did not tell Eloquent which table to use for our `Flight` model. By convention, the "snake case", plural name of the class will be used as the table name unless another name is explicitly specified. So, in this case, Eloquent will assume the `Flight` model stores records in the `flights` table. You may specify a custom table by defining a `table` property on your model:
+
+생성한 `Flight` 모델에서 어떠한 테이블을 사용해야할지 Elquent 에게 알려주지 않았다는 점을 주목하십시오. 관례적으로 연관된 테이블이 별도로 지정되지 않는다면 클래스의 "스네이크 케이스" 로 표시된 복수형의 이름이 사용되어 집니다. 따라서 이 예제에서는 Eloquent는 `Flight` 모델은 `flights` 테이블에 레코드를 저장한다고 추정할 것입니다. 여러분은 모델의 `table` 속성을 통해서 고유한 테이블을 지정할 수 있습니다:
 
     <?php
 
@@ -81,14 +121,22 @@ Note that we did not tell Eloquent which table to use for our `Flight` model. By
     }
 
 #### Primary Keys
+#### Primary Keys
 
 Eloquent will also assume that each table has a primary key column named `id`. You may define a protected `$primaryKey` property to override this convention.
 
+Eloquent는 테이블의 primary key 컬럼의 이름을 `id`로 추정합니다. protected `$primaryKey` 속성을 통해서 이 컬럼명을 재정의할 수 있습니다.
+
 In addition, Eloquent assumes that the primary key is an incrementing integer value, which means that by default the primary key will be cast to an `int` automatically. If you wish to use a non-incrementing or a non-numeric primary key you must set the public `$incrementing` property on your model to `false`. If your primary key is not an integer, you should set the protected `$keyType` property on your model to `string`.
 
+추가적으로, Eloquent 는 primary key가 증가하는 정수값(incrementing)이라고 추정합니다. 이는 기본적으로 primary key를 `int`로 자동 캐스팅 한다는 것을 의미합니다. 증가하지 않는(non-incrementing) 또는 숫자형이 아닌 primary key를 사용하고자 한다면, 모델의 public `$incrementing` 속성을 `false` 로 설정해야 합니다. primary key가 정수값(integer)이 아니라면, 모델의 protected `$keyType` 속성을 `string`으로 지정하십시오.
+
 #### Timestamps
+#### 타임스탬프
 
 By default, Eloquent expects `created_at` and `updated_at` columns to exist on your tables.  If you do not wish to have these columns automatically managed by Eloquent, set the `$timestamps` property on your model to `false`:
+
+기본적으로, Eloquent는 테이블에 `created_at` 과 `updated_at` 컬럼이 존재한다고 생각합니다. 자동으로 이 컬럼값이 채워지기를 원하지 않는다면 `$timestamps` 속성을 `false` 로 지정하십시오:
 
     <?php
 
@@ -108,6 +156,8 @@ By default, Eloquent expects `created_at` and `updated_at` columns to exist on y
 
 If you need to customize the format of your timestamps, set the `$dateFormat` property on your model. This property determines how date attributes are stored in the database, as well as their format when the model is serialized to an array or JSON:
 
+타임스탬프의 포맷을 변경하여야 한다면 모델에 `$dateFormat` 속성을 지정하면 됩니다. 이 속성은 날짜 속성이 데이터베이스에 저장될 때의 형식과 모델이 배열이나 JSON으로 직렬화-serialization되었을 때의 형식을 결정합니다:
+
     <?php
 
     namespace App;
@@ -126,6 +176,8 @@ If you need to customize the format of your timestamps, set the `$dateFormat` pr
 
 If you need to customize the names of the columns used to store the timestamps, you may set the `CREATED_AT` and `UPDATED_AT` constants in your model:
 
+만약 타임스탬프를 저장하는 필드의 이름을 수정하고자 하는 경우, 모델에 `CREATED_AT` 그리고 `UPDATED_AT` 상수를 설정하면 됩니다:
+
     <?php
 
     class Flight extends Model
@@ -135,8 +187,11 @@ If you need to customize the names of the columns used to store the timestamps, 
     }
 
 #### Database Connection
+#### 데이터베이스 커넥션
 
 By default, all Eloquent models will use the default database connection configured for your application. If you would like to specify a different connection for the model, use the `$connection` property:
+
+기본적으로 모든 Eloquent 모델은 어플리케이션에서 기본으로 셋팅되어 있는 커넥션을 사용합니다. 다른 커넥션을 지정하고 싶다면 `$connection` 속성을 이용하면 됩니다:
 
     <?php
 
@@ -156,8 +211,11 @@ By default, all Eloquent models will use the default database connection configu
 
 <a name="retrieving-models"></a>
 ## Retrieving Models
+## 모델 조회하기
 
 Once you have created a model and [its associated database table](/docs/{{version}}/migrations#writing-migrations), you are ready to start retrieving data from your database. Think of each Eloquent model as a powerful [query builder](/docs/{{version}}/queries) allowing you to fluently query the database table associated with the model. For example:
+
+하나의 모델과 [해당 모델에 지정된 데이터베이스 테이블](/docs/{{version}}/migrations#writing-migrations)을 생성하였다면, 이제 데이터베이스에서 데이터를 조회할 수 있습니다. 각 Eloquent 모델을 데이터베이스 쿼리를 용이하게 해주는 강력한 [쿼리 빌더](/docs/{{version}}/queries)로 생각하십시오. 예를 들자면:
 
     <?php
 
@@ -170,8 +228,11 @@ Once you have created a model and [its associated database table](/docs/{{versio
     }
 
 #### Adding Additional Constraints
+#### 추가적인 제약조건 추가하기
 
 The Eloquent `all` method will return all of the results in the model's table. Since each Eloquent model serves as a [query builder](/docs/{{version}}/queries), you may also add constraints to queries, and then use the `get` method to retrieve the results:
+
+Eloquent의 `all` 메소드는 모델의 테이블에서 모든 결과를 반환할 것입니다. 각 Eloquent 모델은 [쿼리 빌더](/docs/{{version}}/queries)의 역할을 하기 때문에 쿼리에 다양한 조건들을 추가할 수 있고, 마지막에 `get` 메소드를 사용하여 결과를 조회할 수 있습니다:
 
     $flights = App\Flight::where('active', 1)
                    ->orderBy('name', 'desc')
@@ -180,10 +241,15 @@ The Eloquent `all` method will return all of the results in the model's table. S
 
 > {tip} Since Eloquent models are query builders, you should review all of the methods available on the [query builder](/docs/{{version}}/queries). You may use any of these methods in your Eloquent queries.
 
+> {tip} Eloquent 모델은 모두가 쿼리 빌더이기 때문에, [쿼리 빌더](/docs/{{version}}/queries)에서 제공되는 모든 메소드를 살펴 보시기 바랍니다. 여기의 어떠한 메소드라도 Eloquent 쿼리에서 사용할 수 있습니다.
+
 <a name="collections"></a>
 ### Collections
+### 컬렉션
 
 For Eloquent methods like `all` and `get` which retrieve multiple results, an instance of `Illuminate\Database\Eloquent\Collection` will be returned. The `Collection` class provides [a variety of helpful methods](/docs/{{version}}/eloquent-collections#available-methods) for working with your Eloquent results:
+
+`all`과 `get` 같이 여러개의 결과를 가져오는 Eloquent 메소드의 경우 `Illuminate\Database\Eloquent\Collection` 인스턴스가 반환됩니다. `Collection` 클래스는 Eloquent 결과에 사용할 수 있는 [다양한 메소드](/docs/{{version}}/eloquent-collections#available-methods)들을 제공합니다:
 
     $flights = $flights->reject(function ($flight) {
         return $flight->cancelled;
@@ -191,14 +257,19 @@ For Eloquent methods like `all` and `get` which retrieve multiple results, an in
 
 Of course, you may also loop over the collection like an array:
 
+물론 배열과 동일하게 또한 이 컬렉션을 반복문에서 사용 할 수 있습니다:
+
     foreach ($flights as $flight) {
         echo $flight->name;
     }
 
 <a name="chunking-results"></a>
 ### Chunking Results
+### 결과 분할하기
 
 If you need to process thousands of Eloquent records, use the `chunk` command. The `chunk` method will retrieve a "chunk" of Eloquent models, feeding them to a given `Closure` for processing. Using the `chunk` method will conserve memory when working with large result sets:
+
+수천개의 Eloquent 모델이 필요 할 때에는 `chunk` 명령어를 사용하십시오. `chunk` 메소드는 "분할된" Eloquent 모델들을 가져올 것이며 주어진 `Closure`에 의해서 처리될 것입니다. `chunk` 메소드를 이용하면 결과가 아주 큰 경우 메모리를 절약할 수 있을 것입니다.
 
     Flight::chunk(200, function ($flights) {
         foreach ($flights as $flight) {
@@ -208,9 +279,14 @@ If you need to process thousands of Eloquent records, use the `chunk` command. T
 
 The first argument passed to the method is the number of records you wish to receive per "chunk". The Closure passed as the second argument will be called for each chunk that is retrieved from the database. A database query will be executed to retrieve each chunk of records passed to the Closure.
 
+메소드의 첫번째 인자는 "chunk" 메소드에서 받아 들일 레코드의 갯수 입니다. 두번째 인자는 클로저로 데이터베이스로 부터 분할된 데이터들을 전달 받습니다. 데이터베이스 쿼리는 각가의 분할된 레코드들을 조회하여 클로저에 전달하도록 실행될 것입니다.
+
 #### Using Cursors
+#### 커서 사용하기
 
 The `cursor` method allows you to iterate through your database records using a cursor, which will only execute a single query. When processing large amounts of data, the `cursor` method may be used to greatly reduce your memory usage:
+
+`cursor` 메소드는 단 하나의 쿼리를 실행하는 커서를 사용하여 데이터베이스 레코드 전체를 반복할 수 있게 합니다. 대량의 데이터를 처리하는 경우에, `cursor` 메소드는 메모리 사용량을 크게 줄여줍니다:
 
     foreach (Flight::where('foo', 'bar')->cursor() as $flight) {
         //
@@ -218,8 +294,11 @@ The `cursor` method allows you to iterate through your database records using a 
 
 <a name="retrieving-single-models"></a>
 ## Retrieving Single Models / Aggregates
+## 하나의 모델 / 집계 조회하기
 
 Of course, in addition to retrieving all of the records for a given table, you may also retrieve single records using `find` or `first`. Instead of returning a collection of models, these methods return a single model instance:
+
+테이블에서 모든 정보를 조회하는 것 외에도 `find` 또는 `first`를 이용해서 하나의 레코드를 찾을 수 있습니다. 이 메소드들은 모델 컬렉션을 반환하는 대신 모델 인스턴스 하나를 반환합니다:
 
     // Retrieve a model by its primary key...
     $flight = App\Flight::find(1);
@@ -229,11 +308,16 @@ Of course, in addition to retrieving all of the records for a given table, you m
 
 You may also call the `find` method with an array of primary keys, which will return a collection of the matching records:
 
+또한 `find` 메소드를 primary key 의 배열과 함께 사용하여 매칭되는 레코드들의 컬렉션을 반환받을 수 있습니다:
+
     $flights = App\Flight::find([1, 2, 3]);
 
 #### Not Found Exceptions
+#### Not Found Exceptions
 
 Sometimes you may wish to throw an exception if a model is not found. This is particularly useful in routes or controllers. The `findOrFail` and `firstOrFail` methods will retrieve the first result of the query; however, if no result is found, a `Illuminate\Database\Eloquent\ModelNotFoundException` will be thrown:
+
+모델을 찾지 못했을 때에는 Exception을 던지고 싶을 수도 있으며 특히 라우트나 컨트롤러에서 유용합니다. `findOrFail`와 `firstOrFail` 메소드는 쿼리의 첫번째 결과를 반환하지만 결과를 찾을 수 없을 때에는 `Illuminate\Database\Eloquent\ModelNotFoundException`가 던져질 것입니다:
 
     $model = App\Flight::findOrFail(1);
 
@@ -241,14 +325,19 @@ Sometimes you may wish to throw an exception if a model is not found. This is pa
 
 If the exception is not caught, a `404` HTTP response is automatically sent back to the user. It is not necessary to write explicit checks to return `404` responses when using these methods:
 
+예외를 처리하지 않는다면 `404` HTTP 응답이 자동으로 사용자에게 보내집니다. 이 메소드들을 사용할 때 `404` 응답을 반환하는 것을 명시적으로 선언할 필요는 없습니다.
+
     Route::get('/api/flights/{id}', function ($id) {
         return App\Flight::findOrFail($id);
     });
 
 <a name="retrieving-aggregates"></a>
 ### Retrieving Aggregates
+### 합계 조회하기
 
 You may also use the `count`, `sum`, `max`, and other [aggregate methods](/docs/{{version}}/queries#aggregates) provided by the [query builder](/docs/{{version}}/queries). These methods return the appropriate scalar value instead of a full model instance:
+
+[쿼리 빌더](/docs/{{version}}/queries)가 제공하는 `count`, `sum`, `max`을 비롯한 [집계 메소드](/docs/{{version}}/queries#aggregates)를 이용할 수 있습니다. 이 메소드들은 모델의 인스턴스 대신 적절한 스칼라 값을 반환합니다.
 
     $count = App\Flight::where('active', 1)->count();
 
@@ -256,11 +345,15 @@ You may also use the `count`, `sum`, `max`, and other [aggregate methods](/docs/
 
 <a name="inserting-and-updating-models"></a>
 ## Inserting & Updating Models
+## 모델 추가하기 & 수정하기
 
 <a name="inserts"></a>
 ### Inserts
+### Inserts
 
 To create a new record in the database, create a new model instance, set attributes on the model, then call the `save` method:
+
+데이터베이스에 새로운 레코드를 생성하기 위해는, 새 모델의 인스턴스를 생성하고 모델의 속성을 설정하여, `save` 메소드를 호출하면 됩니다:
 
     <?php
 
@@ -292,10 +385,15 @@ To create a new record in the database, create a new model instance, set attribu
 
 In this example, we assign the `name` parameter from the incoming HTTP request to the `name` attribute of the `App\Flight` model instance. When we call the `save` method, a record will be inserted into the database. The `created_at` and `updated_at` timestamps will automatically be set when the `save` method is called, so there is no need to set them manually.
 
+이 예제에서 HTTP 요청에서 확인된 `name` 파라미터를 `App\Flight` 모델 인스턴스의 `name` 속성에 지정합니다. `save` 메소드를 호출하면 데이터베이스에 레코드가 추가 될 것입니다. `save` 메소드를 호출하면 `created_at`와 `updated_at` 타임스탬프가 자동으로 설정되며 수동으로 지정할 필요가 없습니다.
+
 <a name="updates"></a>
+### Updates
 ### Updates
 
 The `save` method may also be used to update models that already exist in the database. To update a model, you should retrieve it, set any attributes you wish to update, and then call the `save` method. Again, the `updated_at` timestamp will automatically be updated, so there is no need to manually set its value:
+
+`save` 메소드는 데이터베이스에 이미 존재하는 모델들을 업데이트 하기 위해 사용될 수 있습니다. 모델을 업데이트하기 위해서는 모델을 조회한 다음, 업데이트하기 원하는 속성을 수정한 뒤 `save` 메소드를 호출합니다. 이 때에도 `updated_at` 타임스탬프는 자동으로 설정되며 수동으로 값을 지정할 필요가 없습니다:
 
     $flight = App\Flight::find(1);
 
@@ -304,8 +402,11 @@ The `save` method may also be used to update models that already exist in the da
     $flight->save();
 
 #### Mass Updates
+#### 여러개의 모델 Update
 
 Updates can also be performed against any number of models that match a given query. In this example, all flights that are `active` and have a `destination` of `San Diego` will be marked as delayed:
+
+주어진 쿼리에 일치하는 여러개의 모델들에 대해서 업데이트를 할 수 있습니다. 다음의 예제에서는 `active` 하면서, `destination` 이 `San Diego` 인 모든 비행편들이 연기되었다고 표시될 것입니다:
 
     App\Flight::where('active', 1)
               ->where('destination', 'San Diego')
@@ -313,16 +414,27 @@ Updates can also be performed against any number of models that match a given qu
 
 The `update` method expects an array of column and value pairs representing the columns that should be updated.
 
+`update` 메소드는 컬럼의 정렬과 업데이트 될 컬럼을 대표하는 값의 배열을 필요로 합니다.
+
 > {note} When issuing a mass update via Eloquent, the `saved` and `updated` model events will not be fired for the updated models. This is because the models are never actually retrieved when issuing a mass update.
+
+> {note} Eloquent를 통해서 여러개의 모델을 업데이트 할 때, 변경되는 모델에 대한 `saved` 및 `updated` 모델 이벤트는 발생되지 않습니다. 이 이유는 여러개의 모델을 업데이트 할 때 실제로 모델이 조회되는 것이 아니기 때문입니다.
 
 <a name="mass-assignment"></a>
 ### Mass Assignment
+### 대량 할당 - Mass Assignment
 
 You may also use the `create` method to save a new model in a single line. The inserted model instance will be returned to you from the method. However, before doing so, you will need to specify either a `fillable` or `guarded` attribute on the model, as all Eloquent models protect against mass-assignment by default.
 
+`create` 메소드를 통해 한줄에서 바로 새로운 모델을 추가할 수도 있습니다. 메소드를 통해 추가된 모델 인스턴스가 결과로 반환될 것입니다. 하지만 기본적으로 모든 Eloquent 모델은 대량 할당-Mass Assignment 으로부터 보호되기 때문에, 이렇게 하기 전에 모델의 `fillable`나 `guarded` 속성을 지정해야 주어야 합니다.
+
 A mass-assignment vulnerability occurs when a user passes an unexpected HTTP parameter through a request, and that parameter changes a column in your database you did not expect. For example, a malicious user might send an `is_admin` parameter through an HTTP request, which is then passed into your model's `create` method, allowing the user to escalate themselves to an administrator.
 
+대량 할당(Mass Assignment)의 취약성은 사용자가 예상치 못한 HTTP 요청 파라미터를 전달했을 때 발생하며, 해당 파라미터는 데이터베이스의 예상하지 못한 컬럼을 변경하게 됩니다. 예를 들어 악의적인 사용자는 HTTP 요청을 통해 `is_admin`을 전달할 수 있으며 이 파라미터는 모델의 `create` 메소드에 전달되어 사용자를 관리자로 승격할 수 있습니다.
+
 So, to get started, you should define which model attributes you want to make mass assignable. You may do this using the `$fillable` property on the model. For example, let's make the `name` attribute of our `Flight` model mass assignable:
+
+따라서 시작하기 위해서는 대량 할당(Mass Assignment)할 모델의 속성을 정의해야 하며 이는 모델에 `$fillable` 속성을 사용해서 할 수 있습니다. 예를 들어 `Flight` 모델에서 `name` 속성을 대량 할당(Mass Assignment)될 수 있도록 만들 수 있습니다:
 
     <?php
 
@@ -342,15 +454,22 @@ So, to get started, you should define which model attributes you want to make ma
 
 Once we have made the attributes mass assignable, we can use the `create` method to insert a new record in the database. The `create` method returns the saved model instance:
 
+속성을 대량 할당될(mass assignable) 수 있도록 만든 뒤에는 `create` 메소드로 데이터베이스에 새로운 레코드을 추가할 수 있습니다. `create` 메소드는 저장된 모델 인스턴스를 반환합니다:
+
     $flight = App\Flight::create(['name' => 'Flight 10']);
 
 If you already have a model instance, you may use the `fill` method to populate it with an array of attributes:
 
+이미 모델 인스턴스를 가지고 있다면, `fill` 메소드에 배열을 전달하여 속성을 구성할 수 있습니다:
+
     $flight->fill(['name' => 'Flight 22']);
 
 #### Guarding Attributes
+#### 속성들 보호하기
 
 While `$fillable` serves as a "white list" of attributes that should be mass assignable, you may also choose to use `$guarded`. The `$guarded` property should contain an array of attributes that you do not want to be mass assignable. All other attributes not in the array will be mass assignable. So, `$guarded` functions like a "black list". Of course, you should use either `$fillable` or `$guarded` - not both. In the example below, all attributes **except for `price`** will be mass assignable:
+
+`$fillable`는 대량 할당(mass assign)될 수 있는 속성들의 화이트 리스트로써 동작 하지만, `$guarded`를 사용할 수도 있습니다. `$guarded` 속성은 대량 할당(mass assign)하고 싶지 않은 속성들의 배열을 가지고 있을 것입니다. 이 배열에 포함되지 않은 모든 속성들은 대량 할당될 수 있을 것입니다. 따라서 `$guarded`는 블랙리스트와 같은 기능을 합니다. 물론 `$fillable`나 `$guarded` 둘 중 하나만을 사용해야 합니다. 다음 예제에서 **`price`**를 제외한 모든 속성들은 대량 할당이 가능합니다:
 
     <?php
 
@@ -370,6 +489,8 @@ While `$fillable` serves as a "white list" of attributes that should be mass ass
 
 If you would like to make all attributes mass assignable, you may define the `$guarded` property as an empty array:
 
+모든 속성들이 대량 할당이 가능하게 하고자 한다면, `$guarded` 프로퍼티를 빈 배열로 정의하면 됩니다.
+
     /**
      * The attributes that aren't mass assignable.
      *
@@ -379,12 +500,18 @@ If you would like to make all attributes mass assignable, you may define the `$g
 
 <a name="other-creation-methods"></a>
 ### Other Creation Methods
+### 기타 생성을 위한 메소드들
 
+#### `firstOrCreate`/ `firstOrNew`
 #### `firstOrCreate`/ `firstOrNew`
 
 There are two other methods you may use to create models by mass assigning attributes: `firstOrCreate` and `firstOrNew`. The `firstOrCreate` method will attempt to locate a database record using the given column / value pairs. If the model can not be found in the database, a record will be inserted with the attributes from the first parameter, along with those in the optional second parameter.
 
+속성을 대량 할당(mass assign) 하여 모델을 생성하는 또다른 방법은 `firstOrCreate`와 `firstOrNew`의 두 가지가 있습니다. `firstOrCreate` 메소드는 주어진 컬럼 / 값의 쌍을 이용하여 데이터베이스 레코드를 찾으려고 시도할 것입니다. 데이터베이스에서 모델을 찾을 수 없으면 주어진 첫번째 속성과 두번째 속성을 기반으로 새로운 레코드를 입력합니다.
+
 The `firstOrNew` method, like `firstOrCreate` will attempt to locate a record in the database matching the given attributes. However, if a model is not found, a new model instance will be returned. Note that the model returned by `firstOrNew` has not yet been persisted to the database. You will need to call `save` manually to persist it:
+
+`firstOrCreate`와 같이 `firstOrNew` 메소드도 주어진 속성들에 해당하는 레코드를 데이터베이스에서 찾으려고 시도할 것입니다. 하지만 모델을 찾을 수 없으면 새로운 모델 인스턴스가 반환될 것입니다. `firstOrNew`에 의해 반환된 모델은 아직 데이터베이스에서 저장되지 않았다는 점에 주의하십시오. 모델을 저장하기 위해서는 `save`를 수동으로 호출해야 합니다:
 
     // Retrieve flight by name, or create it if it doesn't exist...
     $flight = App\Flight::firstOrCreate(['name' => 'Flight 10']);
@@ -403,8 +530,11 @@ The `firstOrNew` method, like `firstOrCreate` will attempt to locate a record in
     );
 
 #### `updateOrCreate`
+#### `updateOrCreate`
 
 You may also come across situations where you want to update an existing model or create a new model if none exists. Laravel provides an `updateOrCreate` method to do this in one step. Like the `firstOrCreate` method, `updateOrCreate` persists the model, so there's no need to call `save()`:
+
+또한 모델이 존재하는 경우에 이를 업데이트하고, 존재하지 않는 경우에는 새로운 모델을 생성할 수도 있습니다. 라라벨은 이런 경우 한번에 처리할 수 있는 `updateOrCreate` 메소드를 제공합니다. `firstOrCreate`메소드 처럼 `updateOrCreate` 모델을 직접 저장하므로, `save()` 메소드를 호출할 필요가 없습니다:
 
     // If there's a flight from Oakland to San Diego, set the price to $99.
     // If no matching model exists, create one.
@@ -415,16 +545,22 @@ You may also come across situations where you want to update an existing model o
 
 <a name="deleting-models"></a>
 ## Deleting Models
+## 모델 삭제하기
 
 To delete a model, call the `delete` method on a model instance:
+
+모델을 삭제하기 위해서는 모델 인스턴스에 `delete` 메소드를 호출하면 됩니다:
 
     $flight = App\Flight::find(1);
 
     $flight->delete();
 
 #### Deleting An Existing Model By Key
+#### 키를 통해서 이미 존재하는 모델 삭제하기
 
 In the example above, we are retrieving the model from the database before calling the `delete` method. However, if you know the primary key of the model, you may delete the model without retrieving it. To do so, call the `destroy` method:
+
+위의 예제에서는 `delete` 메소드를 호출하기 전에 데이터베이스에서 모델을 조회합니다. 하지만 모델의 프라이머리 키를 알고 있다면 모델을 조회하지 않고 바로 삭제할 수 있습니다. 이렇게 하기 위해서는 `destroy` 메소드를 호출합니다:
 
     App\Flight::destroy(1);
 
@@ -433,17 +569,25 @@ In the example above, we are retrieving the model from the database before calli
     App\Flight::destroy(1, 2, 3);
 
 #### Deleting Models By Query
+#### 쿼리를 통해서 모델 삭제하기
 
 Of course, you may also run a delete statement on a set of models. In this example, we will delete all flights that are marked as inactive. Like mass updates, mass deletes will not fire any model events for the models that are deleted:
+
+물론 모델들에 대해서 삭제 구문을 실행할 수도 있습니다. 아래의 예제는 비활성으로 표시된 모든 항공편들을 삭제할 것입니다. 대량 수정과 같이 대량으로 삭제하는 것은 삭제된 모델에 대한 어떠한 모델 이벤트도 발생시키지 않을 것입니다:
 
     $deletedRows = App\Flight::where('active', 0)->delete();
 
 > {note} When executing a mass delete statement via Eloquent, the `deleting` and `deleted` model events will not be fired for the deleted models. This is because the models are never actually retrieved when executing the delete statement.
 
+> {note} Eloquent 를 통해서 대량으로 삭제 구문을 실행할 때, 삭제되는 모델에 대한 `deleting` 및  `deleted` 모델 이벤트는 발생되지 않습니다. 이 이유는 삭제 구문을 실행할 때 실제로 모델이 조회 되는 것이 아니기 때문입니다.
+
 <a name="soft-deleting"></a>
 ### Soft Deleting
+### 소프트 삭제하기
 
 In addition to actually removing records from your database, Eloquent can also "soft delete" models. When models are soft deleted, they are not actually removed from your database. Instead, a `deleted_at` attribute is set on the model and inserted into the database. If a model has a non-null `deleted_at` value, the model has been soft deleted. To enable soft deletes for a model, use the `Illuminate\Database\Eloquent\SoftDeletes` trait on the model and add the `deleted_at` column to your `$dates` property:
+
+실제로 데이터베이스에서 기록을 삭제하는 것 외에도 Eloquent는 모델을 "소프트 삭제(일종의 임시 삭제)"할 수 있습니다. 소프트 삭제된 모델은 실제로 데이터베이스에서 삭제된 것은 아닙니다. 대신 모델에 `deleted_at` 속성이 지정되어 데이터베이스에 입력됩니다. 모델이 null이 아닌 `deleted_at` 값을 가진다면 그 모델은 소프트 삭제된 것입니다. 모델이 소프트 삭제되는 것을 허용하기 위해 모델에 `Illuminate\Database\Eloquent\SoftDeletes` 속성을 이용하고 `$dates` 속성에 `deleted_at` 컬럼을 추가하세요:
 
     <?php
 
@@ -466,13 +610,19 @@ In addition to actually removing records from your database, Eloquent can also "
 
 Of course, you should add the `deleted_at` column to your database table. The Laravel [schema builder](/docs/{{version}}/migrations) contains a helper method to create this column:
 
+물론 데이터베이스 테이블에 `deleted_at` 컬럼을 추가해야 합니다. 라라벨의 [스키마 빌더](/docs/{{version}}/migrations)는 이 컬럼을 생성하는 도우미 메소드를 가지고 있습니다:
+
     Schema::table('flights', function ($table) {
         $table->softDeletes();
     });
 
 Now, when you call the `delete` method on the model, the `deleted_at` column will be set to the current date and time. And, when querying a model that uses soft deletes, the soft deleted models will automatically be excluded from all query results.
 
+이제 모델에 `delete` 메소드를 호출하면 `deleted_at` 컬럼은 현재 날짜와 시간에 맞춰질 것입니다. 또한 소프트 삭제된 모델을 쿼리할 때 소프트 삭제된 모든 모델은 자동적으로 쿼리 결과에서 제외됩니다.
+
 To determine if a given model instance has been soft deleted, use the `trashed` method:
+
+주어지 모델 인스턴스가 소프트 삭제되었는지 확인하려면 `trashed` 메소드를 사용하세요:
 
     if ($flight->trashed()) {
         //
@@ -480,10 +630,14 @@ To determine if a given model instance has been soft deleted, use the `trashed` 
 
 <a name="querying-soft-deleted-models"></a>
 ### Querying Soft Deleted Models
+### 소프트 삭제된 모델 쿼리하기
 
 #### Including Soft Deleted Models
+#### 소프트 삭제된 모델 포함하기
 
 As noted above, soft deleted models will automatically be excluded from query results. However, you may force soft deleted models to appear in a result set using the `withTrashed` method on the query:
+
+위에서 본 바와 같이, 소프트 삭제된 모델들은 쿼리 결과에서 자동으로 제외됩니다. 하지만 쿼리에 `withTrashed` 메소드를 쓰면 결과 세트에 소프트 삭제된 모델도 나타나도록 강제할 수 있습니다:
 
     $flights = App\Flight::withTrashed()
                     ->where('account_id', 1)
@@ -491,23 +645,33 @@ As noted above, soft deleted models will automatically be excluded from query re
 
 The `withTrashed` method may also be used on a [relationship](/docs/{{version}}/eloquent-relationships) query:
 
+`withTrashed` 메소드는 [관계](/docs/{{version}}/eloquent-relationships) 쿼리에서도 사용될 수 있습니다:
+
     $flight->history()->withTrashed()->get();
 
 #### Retrieving Only Soft Deleted Models
+#### 소프트 삭제된 모델만 가져오기
 
 The `onlyTrashed` method will retrieve **only** soft deleted models:
+
+`onlyTrashed` 메소드는 소프트 삭제된 모델만 가져옵니다:
 
     $flights = App\Flight::onlyTrashed()
                     ->where('airline_id', 1)
                     ->get();
 
 #### Restoring Soft Deleted Models
+#### 소프트 삭제된 모델 복구하기
 
 Sometimes you may wish to "un-delete" a soft deleted model. To restore a soft deleted model into an active state, use the `restore` method on a model instance:
+
+때로는 소프트 삭제된 모델의 삭제를 취소하고 싶을 수도 있습니다. 소프트 삭제된 모델을 활성화 상태로 복구하려면 모델 인스턴스에 `restore` 메소드를 사용하면 됩니다:
 
     $flight->restore();
 
 You may also use the `restore` method in a query to quickly restore multiple models. Again, like other "mass" operations, this will not fire any model events for the models that are restored:
+
+여러 개의 모델을 빠르게 복구할 때도 `restore` 메소드를 쿼리에 사용할 수 있습니다. 다시한번 말하지만, 다른 "대량" 실행들처럼, 복구되는 모델에 대한 어떠한 모델 이벤트도 발생하지 않습니다:
 
     App\Flight::withTrashed()
             ->where('airline_id', 1)
@@ -515,11 +679,16 @@ You may also use the `restore` method in a query to quickly restore multiple mod
 
 Like the `withTrashed` method, the `restore` method may also be used on [relationships](/docs/{{version}}/eloquent-relationships):
 
+`withTrashed` 메소드 같이 `restore` 메소드도 [관계](/docs/{{version}}/eloquent-relationships)에 쓰일 수 있습니다:
+
     $flight->history()->restore();
 
 #### Permanently Deleting Models
+#### 모델을 영구적으로 삭제하기
 
 Sometimes you may need to truly remove a model from your database. To permanently remove a soft deleted model from the database, use the `forceDelete` method:
+
+데이터베이스에서 완전히 모델을 삭제해야 할 때가 있을 것입니다. 데이터베이스에서 소프트 삭제된 모델을 영구적으로 삭제하기 위해서는 `forceDelete` 모델을 사용하면 됩니다:
 
     // Force deleting a single model instance...
     $flight->forceDelete();
@@ -529,15 +698,22 @@ Sometimes you may need to truly remove a model from your database. To permanentl
 
 <a name="query-scopes"></a>
 ## Query Scopes
+## 쿼리 스코프
 
 <a name="global-scopes"></a>
 ### Global Scopes
+### 글로벌 스코프
 
 Global scopes allow you to add constraints to all queries for a given model. Laravel's own [soft delete](#soft-deleting) functionality utilizes global scopes to only pull "non-deleted" models from the database. Writing your own global scopes can provide a convenient, easy way to make sure every query for a given model receives certain constraints.
 
+글로벌 스코프는 주어진 모델의 모든 쿼리에 범위 제한을 추가할 수 있도록 해줍니다. 라라벨의 고유한 [소프트 삭제](#soft-deleting) 기능은 데이터베이스에서 "삭제되지 않은" 모델에 대해서 글로벌 스코프를 사용합니다. 여러분의 고유한 글로벌 스코프를 작성하는 것은 주어진 모델이 특정 제한을 전달 받을 수 있도록 모든 쿼리에 추가하는 보다 편리하고 손쉬운 방법을 제공할 수 있습니다.
+
 #### Writing Global Scopes
+#### 글로벌 스코프 작성하기
 
 Writing a global scope is simple. Define a class that implements the `Illuminate\Database\Eloquent\Scope` interface. This interface requires you to implement one method: `apply`. The `apply` method may add `where` constraints to the query as needed:
+
+글로벌 스코프를 작성하는 것은 쉽습니다. `Illuminate\Database\Eloquent\Scope` 인터페이스의 구현 클래스를 정의합니다. 이 인터페이스는 `apply` 메소드를 구현해야 합니다. `apply` 메소드는 필요한 `where` 조건을 쿼리에 추가할 수 있습니다:
 
     <?php
 
@@ -564,9 +740,14 @@ Writing a global scope is simple. Define a class that implements the `Illuminate
 
 > {tip} If your global scope is adding columns to the select clause of the query, you should use the `addSelect` method instead of `select`. This will prevent the unintentional replacement of the query's existing select clause.
 
+> {tip} 글로벌 스코프가 쿼리의 select 절에 컬럼을 추가하는 경우 select 대신 `addSelect` 메소드를 사용해야 합니다. 이렇게 하면 쿼리의 기존 `select` 절이 교체되는 실수를 방지할 수 있습니다.
+
 #### Applying Global Scopes
+#### 글로벌 스코프 적용하기
 
 To assign a global scope to a model, you should override a given model's `boot` method and use the `addGlobalScope` method:
+
+글로벌 스코프를 모델에 할당하려면, 주어진 모델의 `boot` 메소드를 오버라이딩 하여 `addGlobalScope` 메소드를 사용해야 합니다:
 
     <?php
 
@@ -592,11 +773,16 @@ To assign a global scope to a model, you should override a given model's `boot` 
 
 After adding the scope, a query to `User::all()` will produce the following SQL:
 
+스코프가 추가되면, `User::all()`은 자동으로 다음과 같은 SQL을 생성할 것입니다:
+
     select * from `users` where `age` > 200
 
 #### Anonymous Global Scopes
+#### 익명의 글로벌 스코프
 
 Eloquent also allows you to define global scopes using Closures, which is particularly useful for simple scopes that do not warrant a separate class:
+
+Eloquent는 또한 별도의 분리된 클래스로 구성하지 않아도 될만큼 간단한 스코프를 구성할 때 유용하도록, 특별히 클로저를 사용하여 글로벌 스코프를 정의할 수도 있습니다.
 
     <?php
 
@@ -623,12 +809,17 @@ Eloquent also allows you to define global scopes using Closures, which is partic
     }
 
 #### Removing Global Scopes
+#### 글로벌 스코프 삭제하기
 
 If you would like to remove a global scope for a given query, you may use the `withoutGlobalScope` method. The method accepts the class name of the global scope as its only argument:
+
+주어진 쿼리에 대해서 글로벌 스코프를 제거하고자 한다면, `withoutGlobalScope` 메소드를 사용하면 됩니다. 이 메소드는 글로벌 스코프의 클래스 이름을 인자로 받아들입니다:
 
     User::withoutGlobalScope(AgeScope::class)->get();
 
 If you would like to remove several or even all of the global scopes, you may use the `withoutGlobalScopes` method:
+
+몇몇 또는 모든 글로벌 스코프를 제거하고자 한다면, 다음처럼 `withoutGlobalScopes` 메소드를 사용할 수 있습니다:
 
     // Remove all of the global scopes...
     User::withoutGlobalScopes()->get();
@@ -640,10 +831,15 @@ If you would like to remove several or even all of the global scopes, you may us
 
 <a name="local-scopes"></a>
 ### Local Scopes
+### 로컬 스코프
 
 Local scopes allow you to define common sets of constraints that you may easily re-use throughout your application. For example, you may need to frequently retrieve all users that are considered "popular". To define a scope, prefix an Eloquent model method with `scope`.
 
+로컬 스코프는 어플리케이션에서 손쉽게, 반복적으로 사용할 수 있는 공통의 범위 제한을 정의할 수 있게 해줍니다. 예로 들어 여러분은 종종 "인기가 높은" 것으로 생각되는 사용자를 조회해야 한다고 합시다. 스코프를 정의하기 위해서는 Eloquent 메소드의 이름에 `scope` 를 접두어로 붙이면 됩니다.
+
 Scopes should always return a query builder instance:
+
+스코프는 항상 쿼리 빌더 인스턴스를 반환할 것입니다:
 
     <?php
 
@@ -677,14 +873,20 @@ Scopes should always return a query builder instance:
     }
 
 #### Utilizing A Local Scope
+#### 로컬 스코프 활용하기
 
 Once the scope has been defined, you may call the scope methods when querying the model. However, you should not include the `scope` prefix when calling the method. You can even chain calls to various scopes, for example:
+
+스코프가 정의되면 모델을 질의할 때 스코프 메소드를 호출할 수 있습니다. 하지만 메소드를 호출할 때는 `scope` 접두어를 포함하면 안됩니다. 또한 다음의 예에서 볼 수 있듯이 다양한 스코프를 연결하여 호출할 수도 있습니다:
 
     $users = App\User::popular()->active()->orderBy('created_at')->get();
 
 #### Dynamic Scopes
+#### 다이나믹 스코프
 
 Sometimes you may wish to define a scope that accepts parameters. To get started, just add your additional parameters to your scope. Scope parameters should be defined after the `$query` parameter:
+
+때로는 파라미터를 수용하는 스코프를 정의하고자 할 수도 있습니다. 이를 위해서는 먼저 간단하게 스코프에 새 파라미터들을 추가하십시오. 스코프 파라미터는 `$query` 인자 뒤에 정의될 것입니다:
 
     <?php
 
@@ -709,16 +911,25 @@ Sometimes you may wish to define a scope that accepts parameters. To get started
 
 Now, you may pass the parameters when calling the scope:
 
+이제 스코프를 호출할 때 파라미터를 전달할 수 있습니다:
+
     $users = App\User::ofType('admin')->get();
 
 <a name="events"></a>
 ## Events
+## 이벤트
 
 Eloquent models fire several events, allowing you to hook into the following points in a model's lifecycle: `retrieved`, `creating`, `created`, `updating`, `updated`, `saving`, `saved`, `deleting`, `deleted`, `restoring`, `restored`. Events allow you to easily execute code each time a specific model class is saved or updated in the database.
 
+Eloquent 모델은 여러 이벤트들을 발생시켜 모델의 라이프사이클의 다양한 지점에 후킹할 수 있도록 합니다: `retrieved`, `creating`, `created`, `updating`, `updated`, `saving`, `saved`, `deleting`, `deleted`, `restoring`, `restored`. 이벤트들은 특정 모델 클래스가 데이터베이스에 저장되거나 업데이트될 때마다 코드를 실행하기 용이하게 해줍니다.
+
 The `retrieved` event will fire when an existing model is retrieved from the database. When a new model is saved for the first time, the `creating` and `created` events will fire. If a model already existed in the database and the `save` method is called, the `updating` / `updated` events will fire. However, in both cases, the `saving` / `saved` events will fire.
 
+데이터베이스에서 모델이 존재하고 조회가 되었을때 `retrieved` 이벤트가 발생합니다. 새로운 모델이 처음으로 저장되었을 때 `creating`과 `created` 이벤트가 발생합니다. 모델이 이미 데이터베이스에 존재할 때 `save` 메소드가 호출된다면 `updating` / `updated` 이벤트가 발생합니다. 하지만 이 두 경우 모두 `saving` / `saved` 이벤트가 발생할 것입니다.
+
 To get started, define a `$dispatchesEvents` property on your Eloquent model that maps various points of the Eloquent model's lifecycle to your own [event classes](/docs/{{version}}/events):
+
+이렇게 하기 위해서, Eloquent 모델의 라이프사이클의 다양한 지점을 고유한 이벤트 클래스에 맵핑하는 `$dispatchesEvents` 속성을 Eloquent 모델에 정의하면 됩니다:
 
     <?php
 
@@ -746,8 +957,11 @@ To get started, define a `$dispatchesEvents` property on your Eloquent model tha
 
 <a name="observers"></a>
 ### Observers
+### 옵저버
 
 If you are listening for many events on a given model, you may use observers to group all of your listeners into a single class. Observers classes have method names which reflect the Eloquent events you wish to listen for. Each of these methods receives the model as their only argument. Laravel does not include a default directory for observers, so you may create any directory you like to house your observer classes:
+
+주어진 모델을 여러 이벤트들을 수신하고자 하는 경우, 옵저버를 사용하여 모든 리스너를 하나의 클래스로 구성할 수 있습니다. 옵저버 클래스는 수신하고자 하는 Eloquent 이벤트에 대항하는 메소드 이름을 가집니다. 각각의 이 메소드들은 인자로 모델을 전달 받습니다. 라라벨은 옵저버에대한 기본 디렉토리를 가지고 있지 않기 때문에, 옵저버 클래스를 위한 어떤 디렉토리도 생성할 수 있습니다:
 
     <?php
 
@@ -781,6 +995,8 @@ If you are listening for many events on a given model, you may use observers to 
     }
 
 To register an observer, use the `observe` method on the model you wish to observe. You may register observers in the `boot` method of one of your service providers. In this example, we'll register the observer in the `AppServiceProvider`:
+
+옵저버를 등록하기 위해서는, 관찰할 모델에 대해 `observe` 메소드를 사용하면 됩니다. 서비스 프로바이더의 `boot` 메소드안에서 옵저버를 등록할 수 있습니다. 다음은 예제는 `AppServiceProvider` 에서 옵저버를 등록하는 예제 입니다:
 
     <?php
 

--- a/kr/eloquent.md
+++ b/kr/eloquent.md
@@ -817,6 +817,12 @@ If you would like to remove a global scope for a given query, you may use the `w
 
     User::withoutGlobalScope(AgeScope::class)->get();
 
+Or, if you defined the global scope using a Closure:
+
+혹은, closure를 이용하여 글로벌 스코프를 정의할 수 있습니다:
+
+    User::withoutGlobalScope('age')->get();
+
 If you would like to remove several or even all of the global scopes, you may use the `withoutGlobalScopes` method:
 
 몇몇 또는 모든 글로벌 스코프를 제거하고자 한다면, 다음처럼 `withoutGlobalScopes` 메소드를 사용할 수 있습니다:


### PR DESCRIPTION
1. eloquent.md 부분에서 5.6버전에서 새롭게 추가된 아래 문구를 번역하였습니다.
Or, if you defined the global scope using a Closure:
User::withoutGlobalScope('age')->get();
2. 원본에서 ' : ' 로 끝나는 문장인데, 마침표(' . ')로 번역되어있는 것을 ' : ' 로 변경하였습니다.
3. 기타 자세한 부분은 커밋에 적어두었습니다.
감사합니다.