### PR TITLE
목차의 링크 경로 수정

### DIFF
--- a/kr/documentation.md
+++ b/kr/documentation.md
@@ -74,8 +74,8 @@
 - 보안
     - [Authentication](/docs/{{version}}/authentication)
     - [인증](/docs/{{version}}/authentication)
-    - [API Authentication](/docs/{{version}}/passport)
-    - [API 인증](/docs/{{version}}/passport)
+    - [API Authentication](/docs/{{version}}/api-authentication)
+    - [API 인증](/docs/{{version}}/api-authentication)
     - [Authorization](/docs/{{version}}/authorization)
     - [Authorization-권한승인](/docs/{{version}}/authorization)
     - [Email Verification](/docs/{{version}}/verification)


### PR DESCRIPTION
"API 인증" 문서의 경로가 `/passport` 에서 `/api-authentication` 으로 변경됨