### PR TITLE
configuration.md 번역

### DIFF
--- a/kr/configuration.md
+++ b/kr/configuration.md
@@ -91,10 +91,6 @@ The second value passed to the `env` function is the "default value". This value
 
 `env` 함수에 전달되는 두 번째 인자는 "기본값" 입니다. 이 값은 주어진 키를 위한 환경 변수가 존재하지 않을 때 사용될 것입니다.
 
-Your `.env` file should not be committed to your application's source control, since each developer / server using your application could require a different environment configuration.
-
-개별 개발자와 서버에서 애플리케이션별로 다른 구동 환경 설정을 필요로 하기 때문에, `.env` 파일을 애플리케이션의 소스 컨트롤 시스템에 커밋하지 않아야 합니다.
-
 <a name="determining-the-current-environment"></a>
 ### Determining The Current Environment
 ### 현재 구동환경 결정하기


### PR DESCRIPTION
제거한 문장은 [라라벨 5.3 문서](https://github.com/laravel/docs/blob/5.3/configuration.md#retrieving-environment-configuration)까지 존재했던 문장인데, 반영이 누락되어 있어 수정했습니다.