### PR TITLE
[8.x] Update container, contract, mocking

### DIFF
--- a/kr/container.md
+++ b/kr/container.md
@@ -48,7 +48,7 @@ Let's look at a simple example:
 
     use App\Http\Controllers\Controller;
     use App\Repositories\UserRepository;
-    use App\User;
+    use App\Models\User;
 
     class UserController extends Controller
     {
@@ -358,7 +358,7 @@ For example, you may type-hint a repository defined by your application in a con
 
     namespace App\Http\Controllers;
 
-    use App\Users\Repository as UserRepository;
+    use App\Models\Users\Repository as UserRepository;
 
     class UserController extends Controller
     {

--- a/kr/contracts.md
+++ b/kr/contracts.md
@@ -178,7 +178,7 @@ For example, take a look at this event listener:
     namespace App\Listeners;
 
     use App\Events\OrderWasPlaced;
-    use App\User;
+    use App\Models\User;
     use Illuminate\Contracts\Redis\Factory;
 
     class CacheOrderInformation

--- a/kr/mocking.md
+++ b/kr/mocking.md
@@ -34,7 +34,7 @@ When testing Laravel applications, you may wish to "mock" certain aspects of you
 
 Laravel provides helpers for mocking events, jobs, and facades out of the box. These helpers primarily provide a convenience layer over Mockery so you do not have to manually make complicated Mockery method calls. You can also use [Mockery](http://docs.mockery.io/en/latest/) or PHPUnit to create your own mocks or spies.
 
-라라벨은 기본적으로 이벤트, job 그리고 파사드에 대한 mock 헬퍼를 제공합니다. 이 헬퍼들은 주로 Mockery에서 작동하는 편리한 레이어를 제공하고 있기 때문에, 수동으로 복잡한 Mockery 메소드를 호출할 필요가 없습니다. 여러분의 고유한 mock 이나 spy 객체를 만드는데 자유롭게 [Mockery](http://docs.mockery.io/en/latest/)나 PHPUnit을 사용할 수 있습니다.
+라라벨은 기본적으로 이벤트, job 그리고 파사드에 대한 mock 헬퍼를 제공합니다. 이 헬퍼들은 주로 Mockery에서 작동하는 편리한 레이어를 제공하고 있기 때문에, 수동으로 복잡한 Mockery 메소드를 호출할 필요가 없습니다. 여러분의 고유한 mock 이나 spy 객체를 만드는데 자유롭게 [Mockery](http://docs.mockery.io/en/latest/) 또는 PHPUnit을 사용할 수 있습니다.
 
 <a name="mocking-objects"></a>
 ## Mocking Objects
@@ -201,7 +201,7 @@ If you only want to fake event listeners for a portion of your test, you may use
     namespace Tests\Feature;
 
     use App\Events\OrderCreated;
-    use App\Order;
+    use App\Models\Order;
     use Illuminate\Foundation\Testing\RefreshDatabase;
     use Illuminate\Support\Facades\Event;
     use Illuminate\Foundation\Testing\WithoutMiddleware;


### PR DESCRIPTION
1. Eloquent 파일들의 네임스페이스 변경 적용
2. `mocking.md` 파일에 아래 번역을 일부 수정
```
객체를 만드는데 자유롭게 [Mockery](http://docs.mockery.io/en/latest/)나 PHPUnit을 
```
```
객체를 만드는데 자유롭게 [Mockery](http://docs.mockery.io/en/latest/) 또는 PHPUnit을 
```
