### PR TITLE
fix(migration): 번역 누락과 CSS 안먹혀서 수정함

### DIFF
--- a/kr/migrations.md
+++ b/kr/migrations.md
@@ -450,6 +450,7 @@ The schema builder blueprint offers a variety of methods that correspond to the 
 </style>
 
 <div id="collection-method-list" markdown="1">
+
 [bigIncrements](#column-method-bigIncrements)
 [bigInteger](#column-method-bigInteger)
 [binary](#column-method-binary)
@@ -514,6 +515,7 @@ The schema builder blueprint offers a variety of methods that correspond to the 
 [uuidMorphs](#column-method-uuidMorphs)
 [uuid](#column-method-uuid)
 [year](#column-method-year)
+
 </div>
 
 <a name="column-method-bigIncrements"></a>
@@ -1358,6 +1360,8 @@ You may even pass an array of columns to an index method to create a compound (o
     $table->index(['account_id', 'created_at']);
 
 When creating an index, Laravel will automatically generate an index name based on the table, column names, and the index type, but you may pass a second argument to the method to specify the index name yourself:
+
+인덱스를 생성할 때, 라라벨은 자동으로 테이블, 컬럼 이름, 인덱스 타입을 기반으로 인덱스 이름을 생성하지만, 인덱스 이름을 지정하기 위해 두 번째 인자를 메소드에 전달할 수도 있습니다.
 
     $table->unique('email', 'unique_email');
 


### PR DESCRIPTION
### 453 라인 
원본 : https://laravel.kr/docs/8.x/migrations#사용가능한%20컬럼의%20타입들
수정 : div 태그가 엔터 누락으로 반영되지 않아 추가 

보기 편하시게 After // Before 입니다. 
![image](https://user-images.githubusercontent.com/45850400/158059379-d9bbba5d-b2ce-4de6-a826-3efd1b5a3a0d.png)

### 1364 라인 
원본 : https://laravel.kr/docs/8.x/migrations#사용가능한%20인덱스%20타입 클릭 후 2칸 위로 
수정 : 번역이 누락되어 추가 