### PR TITLE
오타 수정

### DIFF
--- a/kr/routing.md
+++ b/kr/routing.md
@@ -590,7 +590,7 @@ Of course, implicit binding is also possible when using controller methods. Agai
 
 Typically, implicit model binding will not retrieve models that have been [soft deleted](/docs/{{version}}/eloquent#soft-deleting). However, you may instruct the implicit binding to retrieve these models by chaining the `withTrashed` method onto your route's definition:
 
-일반적으로 북시적 모델 바인딩은 [소프트 삭제](/docs/{{version}}/eloquent#soft-deleting)된 모델은 찾을 수 없습니다. 그렇지만 라우트를 정의할 때 `withTrashed` 메서드를 연결하면 묵시적 모델을 조회할 때 소프트 삭제된 모델도 찾을 수 있습니다.
+일반적으로 묵시적 모델 바인딩은 [소프트 삭제](/docs/{{version}}/eloquent#soft-deleting)된 모델은 찾을 수 없습니다. 그렇지만 라우트를 정의할 때 `withTrashed` 메서드를 연결하면 묵시적 모델을 조회할 때 소프트 삭제된 모델도 찾을 수 있습니다.
 
     use App\Models\User;
 


### PR DESCRIPTION
9.x 라우팅 -> 소프트 삭제 모델 항목 내 오타를 수정하였습니다.

* 북시적 -> 묵시적