### PR TITLE
누락 수정

### DIFF
--- a/kr/validation.md
+++ b/kr/validation.md
@@ -1920,6 +1920,8 @@ The field under validation must be present and not empty _only when_ all of the 
 #### required_array_keys:_foo_,_bar_,...
 #### required_array_keys:_foo_,_bar_,...
 
+The field under validation must be an array and must contain at least the specified keys.
+
 지정된 필드는 배열이어야 하며, 지정된 키를 포함해야합니다.
 
 <a name="rule-same"></a>


### PR DESCRIPTION
![스크린샷 2022-07-24 오후 10 28 35](https://user-images.githubusercontent.com/77957573/180649257-8679b91d-2d2a-4fe5-aab2-a84c576ba542.png)

https://laravel.kr/docs/9.x/validation#rule-required-array-keys
required_array_keys 규칙에 대한 h4(제목)이 안 나옵니다.
다른 규칙과 차이는 원문 설명이 누락되어 있는데 이게 표시에 영향을 준 건지는 확실히 모르겠지만 우선 누락 부분 수정해 PR 올립니다.
