### PR TITLE
fix: 오타로 인해 하이퍼링크가 동작하지 않는 부분 수정

### DIFF
--- a/kr/eloquent.md
+++ b/kr/eloquent.md
@@ -1672,7 +1672,7 @@ Instead of using custom event classes, you may register closures that execute wh
 
 If needed, you may utilize [queueable anonymous event listeners](/docs/{{version}}/events#queuable-anonymous-event-listeners) when registering model events. This will instruct Laravel to execute the model event listener in the background using your application's [queue](/docs/{{version}}/queues):
 
-필요한 경우 모델 이벤트를 등록할 때 [대기열에 올릴 수 있는 익명 이벤트 리스너](/docs/{{version}}/events#queuable-anonymous-event-listeners)를 활용할 수 있습니다. 이것은 애플리케이션의 [큐]](/docs/{{version}}/queues)를 사용하여 백그라운드에서 모델 이벤트 리스너를 실행하도록 라라벨에 지시합니다.
+필요한 경우 모델 이벤트를 등록할 때 [대기열에 올릴 수 있는 익명 이벤트 리스너](/docs/{{version}}/events#queuable-anonymous-event-listeners)를 활용할 수 있습니다. 이것은 애플리케이션의 [큐](/docs/{{version}}/queues)를 사용하여 백그라운드에서 모델 이벤트 리스너를 실행하도록 라라벨에 지시합니다.
 
     use function Illuminate\Events\queueable;
 


### PR DESCRIPTION
'큐' 글자 뒤에 대괄호 하나가 더 들어가있어서 링크가 안걸리는 오타 수정한 커밋 입니다.

[해당 부분 링크](https://laravel.kr/docs/9.x/eloquent#%ED%81%B4%EB%A1%9C%EC%A0%80%20%EC%82%AC%EC%9A%A9%ED%95%98%EA%B8%B0)
![image](https://user-images.githubusercontent.com/25719259/197561146-913a18c9-d0e3-4abd-888d-d240d1c92aad.png)
